### PR TITLE
Retain `.git` directory during template cleanup in `cmd/init`

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -65,9 +65,9 @@ func main() {
 		"go.sum",
 		"app.db",
 		"magiclink.db",
-		"app",  // binary
-		"tmp",  // directory
-		".git", // テンプレートのgit履歴を削除
+		"app", // binary
+		"tmp", // directory
+		//".git", // Use this templateでリポジトリを作ってからクローンして使う想定なので、消さない
 	}
 
 	for _, f := range filesToRemove {


### PR DESCRIPTION
- Modified `cmd/init/main.go` to ensure that the `.git` directory is preserved during template cleanup.  
  This allows support for workflows wherein repository history is important and clones are performed first.  
- Added clarifying comments to better convey the expected behavior when retaining `.git`.