### PR TITLE
Datastar レシピ集 /datastar/recipes（認証不要・本番公開）を追加

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -169,6 +169,18 @@ func main() {
 		r.Get("/datastar-test", handlers.DatastarReferencePage)
 	}
 
+	// Datastar レシピ集（認証不要・本番でも公開。DB 非依存のインメモリデモ）。
+	// docs/datastar/datastar-llm-guide.md のお手本。バックエンドは handlers/datastar_recipes.go。
+	r.Get("/datastar/recipes", handlers.DatastarRecipesPage)
+	r.Post("/datastar/recipes/api/counter", handlers.RecipeCounterInc)
+	r.Post("/datastar/recipes/api/todos", handlers.RecipeTodoAdd)
+	r.Delete("/datastar/recipes/api/todos/{id}", handlers.RecipeTodoRemove)
+	r.Get("/datastar/recipes/api/search", handlers.RecipeSearch)
+	r.Get("/datastar/recipes/api/slow", handlers.RecipeSlow)
+	r.Get("/datastar/recipes/api/tick", handlers.RecipeTick)
+	r.Get("/datastar/recipes/api/dialog", handlers.RecipeDialog)
+	r.Post("/datastar/recipes/api/reset", handlers.RecipeReset)
+
 	// MagicLink handlers (net/http ベース)
 	// Handler() は /auth/login, /auth/verify, /auth/logout, /webauthn/* をフルパスで登録
 	mlHandler := ml.Handler()

--- a/docs/datastar/datastar-llm-guide.md
+++ b/docs/datastar/datastar-llm-guide.md
@@ -484,8 +484,69 @@ Official reference: <https://data-star.dev/reference/attributes>
   `__once`/`__window`/`__debounce`/… → `data-on`.
 - **`data-on-intersect`/`-interval`/`-signal-patch`/`data-init`** are distinct
   attribute names (dash form), not `data-on:<event>`.
+- **`__outside` placement:** put `data-on:click__outside` on the **outer container
+  that includes the toggle button**, not on the inner panel. If it's on the inner
+  panel, the toggle's own click counts as "outside" and closes the panel the instant
+  it opens. (Found via real runtime in recipe §8 at `/datastar/recipes`.)
 - **`data-show`**: pair with `style="display: none"` to avoid a flash before hydration.
 - **Pro vs core:** `data-persist`, `data-query-string`, `data-replace-url`,
   `data-animate`, `data-view-transition`, `data-custom-validity`, `data-match-media`,
   `data-on-raf`, `data-on-resize`, `data-scroll-into-view`, `@clipboard`, `@fit`,
   `@intl` are **Pro**. Everything else above is **core**.
+- **Attribute key case** (repeat, because it bites): `data-signals:fooBar` →
+  `foobar`. Keep signal names lowercase.
+
+---
+
+## 12. Backend SSE implementation (datastar-go)
+
+Datastar is backend-driven: the `@get`/`@post`/… actions hit your server and the
+server replies with SSE events that patch elements or signals (the wire format in §7).
+In Go, use `github.com/starfederation/datastar-go/datastar` (verified against
+`datastar-go v1.2.1`):
+
+```go
+import "github.com/starfederation/datastar-go/datastar"
+
+func handler(w http.ResponseWriter, r *http.Request) {
+    // 1. read signals the client sent (from data-bind / data-signals)
+    var sig struct {
+        Query string `json:"query"`
+    }
+    datastar.ReadSignals(r, &sig)
+
+    // 2. open the SSE stream
+    sse := datastar.NewSSE(w, r)
+
+    // 3a. patch DOM — by raw HTML string, by templ component, or by fmt
+    sse.PatchElements(`<div id="x">hi</div>`, datastar.WithSelectorID("x"), datastar.WithModeInner())
+    sse.PatchElementTempl(MyList(items), datastar.WithSelectorID("list"), datastar.WithModeInner())
+
+    // 3b. patch signals — marshal a Go value into client signals
+    sse.MarshalAndPatchSignals(map[string]any{"count": 1})
+
+    // 3c. misc
+    sse.RemoveElementByID("toast")
+    sse.ExecuteScript("document.getElementById('d').showModal()")
+    sse.Redirect("/done")
+}
+```
+
+**Key API**
+- `datastar.NewSSE(w, r) *ServerSentEventGenerator`
+- `datastar.ReadSignals(r, &v)` — unmarshal client signals into a struct pointer
+- `sse.PatchElements(html, opts…)` / `PatchElementTempl(c, opts…)` / `PatchElementf(fmt, …)`
+- `sse.MarshalAndPatchSignals(v)` / `PatchSignals([]byte)` / `…IfMissing` variants
+- `sse.RemoveElementByID(id)` / `RemoveElement(selector)`
+- `sse.ExecuteScript(js)` / `sse.Redirect(url)` / `sse.ConsoleLog(msg)`
+- **Patch options:** `WithSelector(sel)` / `WithSelectorID(id)` / `WithSelectorf(...)` /
+  `WithMode{Outer,Inner,Replace,Append,Prepend,Before,After,Remove}()` /
+  `WithUseViewTransitions(true)` / `WithViewTransitions()`
+
+These options map 1:1 to the SSE `selector` / `mode` / `useViewTransition` data keys in §7.
+
+### Live recipes
+A runnable, source-annotated recipe set is served at **`/datastar/recipes`** (public,
+DB-free in-memory demos): two-way bind, server round-trip counter, in-memory TODO CRUD,
+live search, indicator, polling, dialog, dropdown. Source to copy from:
+`web/components/datastar_recipes.templ` + `internal/handlers/datastar_recipes.go`.

--- a/internal/handlers/datastar_recipes.go
+++ b/internal/handlers/datastar_recipes.go
@@ -1,0 +1,203 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/starfederation/datastar-go/datastar"
+
+	"github.com/naozine/project_crud_with_auth_tmpl/web/components"
+)
+
+// datastar_recipes.go は /datastar/recipes（認証不要・本番でも公開）のバックエンド。
+// docs/datastar/datastar-llm-guide.md のお手本となる「動くレシピ集」を提供する。
+//
+// 安全性: DB には一切触れず、状態はプロセス内インメモリのみ（再起動で消える）。
+// 本番公開でも悪用でデータが壊れないようにしている。状態は全訪問者で共有されるため
+// mutex で保護し、TODO は件数に上限を設け、reset で初期化できる。
+
+const recipeTodoMax = 20
+
+// recipeStore はレシピ集デモ用のインメモリ状態（全訪問者で共有）。
+type recipeStore struct {
+	mu      sync.Mutex
+	counter int
+	todos   []components.RecipeTodo
+	nextID  int
+}
+
+var recipeState = &recipeStore{}
+
+func (s *recipeStore) snapshotTodos() []components.RecipeTodo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]components.RecipeTodo, len(s.todos))
+	copy(out, s.todos)
+	return out
+}
+
+func (s *recipeStore) incr() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.counter++
+	return s.counter
+}
+
+func (s *recipeStore) addTodo(text string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextID++
+	s.todos = append(s.todos, components.RecipeTodo{ID: s.nextID, Text: text})
+	if len(s.todos) > recipeTodoMax {
+		s.todos = s.todos[len(s.todos)-recipeTodoMax:]
+	}
+}
+
+func (s *recipeStore) removeTodo(id int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.todos[:0]
+	for _, t := range s.todos {
+		if t.ID != id {
+			out = append(out, t)
+		}
+	}
+	s.todos = out
+}
+
+func (s *recipeStore) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.counter = 0
+	s.todos = nil
+}
+
+// recipeFruits はライブ検索デモ用の固定リスト。
+var recipeFruits = []string{
+	"apple", "apricot", "banana", "blueberry", "cherry", "grape", "lemon",
+	"mango", "orange", "peach", "pear", "pineapple", "strawberry", "watermelon",
+}
+
+// DatastarRecipesPage はレシピ集ページ本体を描画する（認証不要）。
+func DatastarRecipesPage(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	_ = components.DatastarRecipes(recipeState.snapshotTodos()).Render(r.Context(), w)
+}
+
+// --- レシピ 2: サーバ往復カウンタ（@post → MarshalAndPatchSignals）---
+
+func RecipeCounterInc(w http.ResponseWriter, r *http.Request) {
+	count := recipeState.incr()
+	sse := datastar.NewSSE(w, r)
+	_ = sse.MarshalAndPatchSignals(map[string]any{"count": count})
+}
+
+// --- レシピ 3: インメモリ TODO 追加（ReadSignals → PatchElementTempl でリスト再描画）---
+
+func RecipeTodoAdd(w http.ResponseWriter, r *http.Request) {
+	var sig struct {
+		Text string `json:"text"`
+	}
+	if err := datastar.ReadSignals(r, &sig); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if t := strings.TrimSpace(sig.Text); t != "" {
+		recipeState.addTodo(t)
+	}
+	sse := datastar.NewSSE(w, r)
+	_ = sse.PatchElementTempl(
+		components.RecipeTodoList(recipeState.snapshotTodos()),
+		datastar.WithSelectorID("recipe-todos"),
+		datastar.WithModeInner(),
+	)
+	// 入力欄をクリア
+	_ = sse.MarshalAndPatchSignals(map[string]any{"text": ""})
+}
+
+// --- レシピ 4: TODO 削除（RemoveElementByID は使わずリスト再描画で一貫させる）---
+
+func RecipeTodoRemove(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	recipeState.removeTodo(id)
+	sse := datastar.NewSSE(w, r)
+	_ = sse.PatchElementTempl(
+		components.RecipeTodoList(recipeState.snapshotTodos()),
+		datastar.WithSelectorID("recipe-todos"),
+		datastar.WithModeInner(),
+	)
+}
+
+// --- レシピ 5: ライブ検索（data-on:input__debounce → @get → PatchElementTempl）---
+
+func RecipeSearch(w http.ResponseWriter, r *http.Request) {
+	var sig struct {
+		Query string `json:"query"`
+	}
+	_ = datastar.ReadSignals(r, &sig)
+	q := strings.ToLower(strings.TrimSpace(sig.Query))
+	hits := make([]string, 0, len(recipeFruits))
+	for _, f := range recipeFruits {
+		if q == "" || strings.Contains(f, q) {
+			hits = append(hits, f)
+		}
+	}
+	sse := datastar.NewSSE(w, r)
+	_ = sse.PatchElementTempl(
+		components.RecipeSearchResults(hits),
+		datastar.WithSelectorID("recipe-search-results"),
+		datastar.WithModeInner(),
+	)
+}
+
+// --- レシピ 6: indicator/ローディング（わざと遅延 → data-indicator が反応）---
+
+func RecipeSlow(w http.ResponseWriter, r *http.Request) {
+	time.Sleep(1200 * time.Millisecond)
+	sse := datastar.NewSSE(w, r)
+	_ = sse.PatchElements(
+		`<p id="recipe-slow-result" class="text-green-700">完了しました（サーバ側で1.2秒待機）</p>`,
+		datastar.WithModeOuter(),
+	)
+}
+
+// --- レシピ 7: ポーリング（data-on-interval → @get → PatchElements でサーバ時刻）---
+
+func RecipeTick(w http.ResponseWriter, r *http.Request) {
+	now := time.Now().Format("15:04:05")
+	sse := datastar.NewSSE(w, r)
+	_ = sse.PatchElements(
+		fmt.Sprintf(`<span id="recipe-tick" class="font-mono">%s</span>`, now),
+		datastar.WithModeOuter(),
+	)
+}
+
+// --- レシピ 8: ダイアログ（PatchElementTempl で挿入 → ExecuteScript で showModal）---
+
+func RecipeDialog(w http.ResponseWriter, r *http.Request) {
+	sse := datastar.NewSSE(w, r)
+	_ = sse.PatchElementTempl(
+		components.RecipeDialog(),
+		datastar.WithSelectorID("recipe-dialog-container"),
+		datastar.WithModeInner(),
+	)
+	_ = sse.ExecuteScript("document.getElementById('recipe-dialog')?.showModal()")
+}
+
+// --- リセット（インメモリ状態を初期化してリロード）---
+
+func RecipeReset(w http.ResponseWriter, r *http.Request) {
+	recipeState.reset()
+	sse := datastar.NewSSE(w, r)
+	_ = sse.ExecuteScript("window.location.reload()")
+}

--- a/web/components/datastar_recipes.templ
+++ b/web/components/datastar_recipes.templ
@@ -1,0 +1,160 @@
+package components
+
+import (
+	"fmt"
+
+	"github.com/naozine/project_crud_with_auth_tmpl/internal/version"
+	"github.com/naozine/project_crud_with_auth_tmpl/web/layouts"
+)
+
+// DatastarRecipes は Datastar v1.0.2 の実用パターンを「動くデモ + ソース併記」で
+// 見せるお手本レシピ集（/datastar/recipes、認証不要・本番公開）。
+// バックエンドは internal/handlers/datastar_recipes.go（DB 非依存のインメモリ）。
+
+templ DatastarRecipes(todos []RecipeTodo) {
+	<!DOCTYPE html>
+	<html lang="ja">
+		@layouts.Head("Datastar Recipes") {
+			<script type="module" src={ "/static/js/datastar.js?v=" + version.Commit }></script>
+		}
+		<body class="bg-gray-50 text-gray-900 p-6 font-sans antialiased">
+			<div class="max-w-4xl mx-auto space-y-6">
+				<header class="space-y-1">
+					<h1 class="text-2xl font-bold">Datastar Recipes</h1>
+					<p class="text-sm text-gray-500">
+						v1.0.2 のお手本レシピ集。各カードは動くデモ＋ソース（frontend / backend Go）。
+						詳細は docs/datastar/datastar-llm-guide.md を参照。
+					</p>
+					<p class="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
+						注意: サーバ側の状態（カウンタ・TODO）は DB ではなく<strong>インメモリ</strong>で、
+						<strong>全訪問者で共有</strong>され、プロセス再起動で消えます。デモ用です。
+						<button class="ml-2 underline" data-on:click="@post('/datastar/recipes/api/reset')">状態をリセット</button>
+					</p>
+				</header>
+				<!-- 1. 双方向バインド -->
+				@recipeCard("1. 双方向バインド（front only）", "data-bind で signal と入力を双方向に。式中は $ 付きで参照。", RecipeBindFront, "") {
+					<div data-signals:name="''">
+						<input class="border px-2 py-1 rounded" data-bind:name placeholder="your name"/>
+						<p>Hello, <span data-text="$name"></span></p>
+					</div>
+				}
+				<!-- 2. サーバ往復カウンタ -->
+				@recipeCard("2. サーバ往復カウンタ（signal patch）", "@post でサーバへ。サーバは MarshalAndPatchSignals で count を返す。", RecipeCounterFront, RecipeCounterBack) {
+					<div data-signals:count="0">
+						<button class="bg-blue-600 text-white px-3 py-1 rounded" data-on:click="@post('/datastar/recipes/api/counter')">+1</button>
+						count: <span data-text="$count"></span>
+					</div>
+				}
+				<!-- 3. インメモリ TODO -->
+				@recipeCard("3. インメモリ TODO（CRUD ループ）", "フォーム送信→サーバがリストを PatchElementTempl(inner) で再描画。削除も同様。", RecipeTodoFront, RecipeTodoBack) {
+					<div data-signals:text="''">
+						<form class="flex gap-2" data-on:submit__prevent="@post('/datastar/recipes/api/todos')">
+							<input class="border px-2 py-1 rounded flex-1" data-bind:text placeholder="new todo"/>
+							<button class="bg-blue-600 text-white px-3 py-1 rounded">add</button>
+						</form>
+						<ul id="recipe-todos" class="mt-2 space-y-1">
+							@RecipeTodoList(todos)
+						</ul>
+					</div>
+				}
+				<!-- 4. ライブ検索 -->
+				@recipeCard("4. ライブ検索（debounce + @get）", "入力を __debounce.300ms して @get。サーバが結果リストを再描画。", RecipeSearchFront, RecipeSearchBack) {
+					<div data-signals:query="''">
+						<input class="border px-2 py-1 rounded w-full" data-bind:query data-on:input__debounce.300ms="@get('/datastar/recipes/api/search')" placeholder="search fruit (例: an)"/>
+						<ul id="recipe-search-results" class="mt-2 space-y-1">
+							<li class="text-sm text-gray-400">type to search</li>
+						</ul>
+					</div>
+				}
+				<!-- 5. indicator -->
+				@recipeCard("5. indicator / ローディング", "data-indicator は fetch 中だけ true。data-show で表示制御。", RecipeIndicatorFront, RecipeIndicatorBack) {
+					<div data-indicator:loading>
+						<button class="bg-blue-600 text-white px-3 py-1 rounded" data-on:click="@get('/datastar/recipes/api/slow')">slow request</button>
+						<span data-show="$loading" class="ml-2 text-gray-500">loading…</span>
+						<p id="recipe-slow-result" class="mt-1"></p>
+					</div>
+				}
+				<!-- 6. ポーリング -->
+				@recipeCard("6. ポーリング（data-on-interval）", "1秒ごとに @get でサーバ時刻を取得し PatchElements で差し替え。", RecipePollFront, RecipePollBack) {
+					<div>
+						<div data-on-interval__duration.1s="@get('/datastar/recipes/api/tick')"></div>
+						server time: <span id="recipe-tick" class="font-mono">--:--:--</span>
+					</div>
+				}
+				<!-- 7. ダイアログ -->
+				@recipeCard("7. ダイアログ（SSE patch + showModal）", "サーバが <dialog> を patch し ExecuteScript で showModal() を呼ぶ。", RecipeDialogFront, RecipeDialogBack) {
+					<div>
+						<div id="recipe-dialog-container"></div>
+						<button class="bg-blue-600 text-white px-3 py-1 rounded" data-on:click="@get('/datastar/recipes/api/dialog')">open dialog</button>
+					</div>
+				}
+				<!-- 8. ドロップダウン -->
+				@recipeCard("8. ドロップダウン（__outside で閉じる, front only）", "クリックでトグル、data-on:click__outside で外側クリック時に閉じる。", RecipeDropdownFront, "") {
+					<div data-signals:open="false" data-on:click__outside="$open = false" class="relative inline-block">
+						<button class="bg-gray-200 px-3 py-1 rounded" data-on:click="$open = !$open">menu ▾</button>
+						<div data-show="$open" class="absolute mt-1 bg-white border rounded shadow p-2 space-x-2">
+							<a href="#" class="text-blue-600">item 1</a>
+							<a href="#" class="text-blue-600">item 2</a>
+						</div>
+					</div>
+				}
+			</div>
+		</body>
+	</html>
+}
+
+// recipeCard は1レシピを「タイトル / 説明 / デモ(children) / 折りたたみソース」で描画する。
+templ recipeCard(title string, desc string, front string, back string) {
+	<section class="rounded border bg-white p-4 space-y-2">
+		<h2 class="font-semibold">{ title }</h2>
+		<p class="text-sm text-gray-500">{ desc }</p>
+		<div class="border rounded p-3 bg-gray-50">
+			{ children... }
+		</div>
+		@recipeSource(front, back)
+	</section>
+}
+
+// recipeSource はフロント/バックエンドのお手本コードを折りたたみで表示する。
+templ recipeSource(front string, back string) {
+	<details class="mt-1">
+		<summary class="cursor-pointer text-sm text-blue-600">source</summary>
+		<p class="text-xs text-gray-500 mt-2">frontend (HTML/templ)</p>
+		<pre class="text-xs bg-gray-900 text-gray-100 p-3 rounded overflow-auto"><code>{ front }</code></pre>
+		if back != "" {
+			<p class="text-xs text-gray-500 mt-2">backend (Go, datastar-go)</p>
+			<pre class="text-xs bg-gray-900 text-gray-100 p-3 rounded overflow-auto"><code>{ back }</code></pre>
+		}
+	</details>
+}
+
+// RecipeTodoList は TODO の現在の一覧を描画する（SSE で inner 再描画される）。
+templ RecipeTodoList(todos []RecipeTodo) {
+	if len(todos) == 0 {
+		<li class="text-sm text-gray-400">（まだありません）</li>
+	}
+	for _, t := range todos {
+		<li class="flex items-center gap-2">
+			<span>{ t.Text }</span>
+			<button class="text-red-600 text-sm" data-on:click={ fmt.Sprintf("@delete('/datastar/recipes/api/todos/%d')", t.ID) }>×</button>
+		</li>
+	}
+}
+
+// RecipeSearchResults は検索ヒットを描画する（SSE で inner 再描画される）。
+templ RecipeSearchResults(hits []string) {
+	if len(hits) == 0 {
+		<li class="text-sm text-gray-400">no match</li>
+	}
+	for _, h := range hits {
+		<li class="text-sm">{ h }</li>
+	}
+}
+
+// RecipeDialog は SSE で挿入されるダイアログ本体。
+templ RecipeDialog() {
+	<dialog id="recipe-dialog" class="rounded-lg p-6 backdrop:bg-black/30">
+		<p class="mb-4">これは SSE（PatchElementTempl）で挿入されたダイアログです。</p>
+		<button class="bg-gray-200 px-3 py-1 rounded" data-on:click="document.getElementById('recipe-dialog').close()">close</button>
+	</dialog>
+}

--- a/web/components/recipe_data.go
+++ b/web/components/recipe_data.go
@@ -1,0 +1,113 @@
+package components
+
+// recipe_data.go はレシピ集（/datastar/recipes）で使う型と、画面に表示する
+// 「お手本コード」の文字列を持つ。文字列はデモの実 markup / 実ハンドラと一致させ、
+// 学習者・LLM がそのままコピーできるようにしている。
+
+// RecipeTodo はインメモリ TODO デモの1項目。
+type RecipeTodo struct {
+	ID   int
+	Text string
+}
+
+// 1. 双方向バインド（フロントのみ）
+const RecipeBindFront = `<div data-signals:name="''">
+  <input data-bind:name placeholder="your name"/>
+  <p>Hello, <span data-text="$name"></span></p>
+</div>`
+
+// 2. サーバ往復カウンタ（@post → サーバが signal を patch）
+const RecipeCounterFront = `<div data-signals:count="0">
+  <button data-on:click="@post('/datastar/recipes/api/counter')">+1</button>
+  count: <span data-text="$count"></span>
+</div>`
+
+const RecipeCounterBack = `func RecipeCounterInc(w http.ResponseWriter, r *http.Request) {
+    count := store.incr() // インメモリ。mutex 保護
+    sse := datastar.NewSSE(w, r)
+    sse.MarshalAndPatchSignals(map[string]any{"count": count})
+}`
+
+// 3. インメモリ TODO（追加=ReadSignals→再描画 / 削除=@delete→再描画）
+const RecipeTodoFront = `<div data-signals:text="''">
+  <form data-on:submit__prevent="@post('/datastar/recipes/api/todos')">
+    <input data-bind:text placeholder="new todo"/>
+    <button>add</button>
+  </form>
+  <ul id="recipe-todos"><!-- サーバが PatchElementTempl(inner) で再描画 --></ul>
+</div>`
+
+const RecipeTodoBack = `func RecipeTodoAdd(w http.ResponseWriter, r *http.Request) {
+    var sig struct{ Text string ` + "`json:\"text\"`" + ` }
+    datastar.ReadSignals(r, &sig)
+    store.addTodo(strings.TrimSpace(sig.Text))
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElementTempl(RecipeTodoList(store.snapshotTodos()),
+        datastar.WithSelectorID("recipe-todos"), datastar.WithModeInner())
+    sse.MarshalAndPatchSignals(map[string]any{"text": ""}) // 入力クリア
+}`
+
+// 4. ライブ検索（input を debounce して @get、サーバが結果を patch）
+const RecipeSearchFront = `<div data-signals:query="''">
+  <input data-bind:query
+    data-on:input__debounce.300ms="@get('/datastar/recipes/api/search')"
+    placeholder="search fruit"/>
+  <ul id="recipe-search-results"><!-- サーバが inner で再描画 --></ul>
+</div>`
+
+const RecipeSearchBack = `func RecipeSearch(w http.ResponseWriter, r *http.Request) {
+    var sig struct{ Query string ` + "`json:\"query\"`" + ` }
+    datastar.ReadSignals(r, &sig)
+    hits := filter(fruits, strings.ToLower(sig.Query))
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElementTempl(RecipeSearchResults(hits),
+        datastar.WithSelectorID("recipe-search-results"), datastar.WithModeInner())
+}`
+
+// 5. indicator / ローディング（data-indicator が fetch 中だけ true）
+const RecipeIndicatorFront = `<div data-indicator:loading>
+  <button data-on:click="@get('/datastar/recipes/api/slow')">slow request</button>
+  <span data-show="$loading">loading…</span>
+  <p id="recipe-slow-result"></p>
+</div>`
+
+const RecipeIndicatorBack = `func RecipeSlow(w http.ResponseWriter, r *http.Request) {
+    time.Sleep(1200 * time.Millisecond)
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(` + "`<p id=\"recipe-slow-result\">done</p>`" + `,
+        datastar.WithModeOuter())
+}`
+
+// 6. ポーリング（data-on-interval で定期 @get、サーバ時刻を patch）
+const RecipePollFront = `<div>
+  <div data-on-interval__duration.1s="@get('/datastar/recipes/api/tick')"></div>
+  server time: <span id="recipe-tick" class="font-mono">--:--:--</span>
+</div>`
+
+const RecipePollBack = `func RecipeTick(w http.ResponseWriter, r *http.Request) {
+    now := time.Now().Format("15:04:05")
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(fmt.Sprintf(` + "`<span id=\"recipe-tick\">%s</span>`" + `, now),
+        datastar.WithModeOuter())
+}`
+
+// 7. ダイアログ（サーバが <dialog> を patch して showModal）
+const RecipeDialogFront = `<div id="recipe-dialog-container"></div>
+<button data-on:click="@get('/datastar/recipes/api/dialog')">open dialog</button>`
+
+const RecipeDialogBack = `func RecipeDialog(w http.ResponseWriter, r *http.Request) {
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElementTempl(RecipeDialog(),
+        datastar.WithSelectorID("recipe-dialog-container"), datastar.WithModeInner())
+    sse.ExecuteScript("document.getElementById('recipe-dialog')?.showModal()")
+}`
+
+// 8. ドロップダウン（クリックでトグル、外側クリックで閉じる。フロントのみ）
+// __outside はトグルボタンを含む外側コンテナに付ける。内側に付けると
+// ボタン自身のクリックが「外側」と判定され、開いた瞬間に閉じてしまう。
+const RecipeDropdownFront = `<div data-signals:open="false" data-on:click__outside="$open = false" class="relative">
+  <button data-on:click="$open = !$open">menu</button>
+  <div data-show="$open">
+    <a href="#">item 1</a> <a href="#">item 2</a>
+  </div>
+</div>`


### PR DESCRIPTION
## 概要
`datastar-llm-guide` のバックエンド実装を補うため、フロント＋バックエンド（`datastar-go`）の往復を**実際に動かして見せるお手本レシピ集**を追加する。本体機能とは別ルート、認証不要・本番でも公開。

## 安全性
DB には一切触れず、状態は**インメモリ**のみ（mutex 保護・件数上限・リセット可・プロセス再起動で消える）。本番公開でも悪用でデータが壊れない。

## レシピ（各カードに動くデモ＋ソース併記）
1. 双方向バインド　2. サーバ往復カウンタ（`MarshalAndPatchSignals`）
3. インメモリ TODO CRUD（`ReadSignals`→`PatchElementTempl`）　4. ライブ検索（`__debounce`→`@get`）
5. indicator　6. ポーリング（`data-on-interval`）　7. ダイアログ（`PatchElementTempl`+`showModal`）　8. ドロップダウン（`__outside`）

## 変更
| ファイル | 内容 |
|---|---|
| `internal/handlers/datastar_recipes.go` | インメモリストア＋8 SSE ハンドラ |
| `web/components/datastar_recipes.templ` + `recipe_data.go` | デモ＋お手本ソース |
| `cmd/server/main.go` | 認証不要ルート登録 |
| `docs/datastar/datastar-llm-guide.md` | §12 バックエンド SSE 実装（datastar-go）＋レシピリンク、`__outside` の落とし穴 |

## 検証
- 全8レシピを Claude in Chrome で実機確認（counter/TODO/search/indicator/polling/dialog/dropdown の往復すべて動作）
- 検証中に発見した `__outside` の配置バグ（内側に付けると開いた瞬間に閉じる）を修正
- `make build` / `make vet` / `make lint`(0 issues) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)