### PR TITLE
レシピ集の UI 修正: ダイアログ中央配置とドロップダウン項目

### DIFF
--- a/web/components/datastar_recipes.templ
+++ b/web/components/datastar_recipes.templ
@@ -90,12 +90,15 @@ templ DatastarRecipes(todos []RecipeTodo) {
 				}
 				<!-- 8. ドロップダウン -->
 				@recipeCard("8. ドロップダウン（__outside で閉じる, front only）", "クリックでトグル、data-on:click__outside で外側クリック時に閉じる。", RecipeDropdownFront, "") {
-					<div data-signals:open="false" data-on:click__outside="$open = false" class="relative inline-block">
-						<button class="bg-gray-200 px-3 py-1 rounded" data-on:click="$open = !$open">menu ▾</button>
-						<div data-show="$open" class="absolute mt-1 bg-white border rounded shadow p-2 space-x-2">
-							<a href="#" class="text-blue-600">item 1</a>
-							<a href="#" class="text-blue-600">item 2</a>
+					<div data-signals:open="false" data-signals:choice="'(none)'">
+						<div data-on:click__outside="$open = false" class="relative inline-block">
+							<button class="bg-gray-200 px-3 py-1 rounded" data-on:click="$open = !$open">menu ▾</button>
+							<div data-show="$open" class="absolute mt-1 bg-white border rounded shadow p-1 flex flex-col min-w-32">
+								<button class="text-left px-2 py-1 rounded hover:bg-gray-100" data-on:click="$choice = 'item 1'; $open = false">item 1</button>
+								<button class="text-left px-2 py-1 rounded hover:bg-gray-100" data-on:click="$choice = 'item 2'; $open = false">item 2</button>
+							</div>
 						</div>
+						<p class="mt-2 text-sm">selected: <span data-text="$choice"></span></p>
 					</div>
 				}
 			</div>
@@ -153,7 +156,9 @@ templ RecipeSearchResults(hits []string) {
 
 // RecipeDialog は SSE で挿入されるダイアログ本体。
 templ RecipeDialog() {
-	<dialog id="recipe-dialog" class="rounded-lg p-6 backdrop:bg-black/30">
+	<!-- m-auto: Tailwind preflight が margin:0 を当てて <dialog> の既定の中央配置を
+	     消すため、明示的に margin:auto で中央に戻す -->
+	<dialog id="recipe-dialog" class="m-auto rounded-lg p-6 backdrop:bg-black/30">
 		<p class="mb-4">これは SSE（PatchElementTempl）で挿入されたダイアログです。</p>
 		<button class="bg-gray-200 px-3 py-1 rounded" data-on:click="document.getElementById('recipe-dialog').close()">close</button>
 	</dialog>

--- a/web/components/recipe_data.go
+++ b/web/components/recipe_data.go
@@ -105,9 +105,14 @@ const RecipeDialogBack = `func RecipeDialog(w http.ResponseWriter, r *http.Reque
 // 8. ドロップダウン（クリックでトグル、外側クリックで閉じる。フロントのみ）
 // __outside はトグルボタンを含む外側コンテナに付ける。内側に付けると
 // ボタン自身のクリックが「外側」と判定され、開いた瞬間に閉じてしまう。
-const RecipeDropdownFront = `<div data-signals:open="false" data-on:click__outside="$open = false" class="relative">
-  <button data-on:click="$open = !$open">menu</button>
-  <div data-show="$open">
-    <a href="#">item 1</a> <a href="#">item 2</a>
+// 項目は <a href="#"> ではなく button にする（href="#" はページ先頭へ飛ぶ）。
+const RecipeDropdownFront = `<div data-signals:open="false" data-signals:choice="'(none)'">
+  <div data-on:click__outside="$open = false" class="relative">
+    <button data-on:click="$open = !$open">menu</button>
+    <div data-show="$open">
+      <button data-on:click="$choice = 'item 1'; $open = false">item 1</button>
+      <button data-on:click="$choice = 'item 2'; $open = false">item 2</button>
+    </div>
   </div>
+  <p>selected: <span data-text="$choice"></span></p>
 </div>`


### PR DESCRIPTION
## 概要
`/datastar/recipes` の実機確認で見つかった UI の不具合2点を修正。

## 修正
1. **ダイアログ（レシピ7）が左上に張り付く** → 中央表示に
   - 原因: Tailwind preflight が `<dialog>` の既定 `margin: auto`（モーダルの中央配置）を `margin: 0` で打ち消していた
   - 修正: dialog に `m-auto` を付与（理由をコメント明記）
2. **ドロップダウン（レシピ8）の項目クリックでページ先頭へ飛ぶ** → 実用的な挙動に
   - 原因: 項目が `<a href="#">` で、`#` の標準挙動でトップへスクロール
   - 修正: 項目を `button` にし、選択値を signal（`choice`）へ格納してメニューを閉じる。`selected:` 表示を追加

## 検証
- 両方 Claude in Chrome で実機確認（ダイアログ中央表示、item 選択で値反映・メニュークローズ・トップに飛ばない）
- `make build` / `make vet` / `make lint`(0 issues) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)