### PR TITLE
レシピ集に仮想スクロール（JS 不要・サーバ往復型）を追加

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -179,6 +179,7 @@ func main() {
 	r.Get("/datastar/recipes/api/slow", handlers.RecipeSlow)
 	r.Get("/datastar/recipes/api/tick", handlers.RecipeTick)
 	r.Get("/datastar/recipes/api/dialog", handlers.RecipeDialog)
+	r.Get("/datastar/recipes/api/vrows", handlers.RecipeVRows)
 	r.Post("/datastar/recipes/api/reset", handlers.RecipeReset)
 
 	// MagicLink handlers (net/http ベース)

--- a/docs/datastar/datastar-llm-guide.md
+++ b/docs/datastar/datastar-llm-guide.md
@@ -548,5 +548,20 @@ These options map 1:1 to the SSE `selector` / `mode` / `useViewTransition` data 
 ### Live recipes
 A runnable, source-annotated recipe set is served at **`/datastar/recipes`** (public,
 DB-free in-memory demos): two-way bind, server round-trip counter, in-memory TODO CRUD,
-live search, indicator, polling, dialog, dropdown. Source to copy from:
+live search, indicator, polling, dialog, dropdown, and a **JS-free virtual scroll**
+(server round-trip windowing). Source to copy from:
 `web/components/datastar_recipes.templ` + `internal/handlers/datastar_recipes.go`.
+
+> **Virtual scroll — core vs Pro.** The core recipe keeps the DOM to a fixed number
+> of rows by re-fetching the visible window on scroll (`data-on:scroll__throttle`
+> sets a start-index signal → `@get` → server patches only that window with a
+> `translateY` offset; a spacer holds the full height). It avoids infinite-scroll's
+> DOM bloat, but because it re-fetches the window on scroll, its smoothness
+> **depends on round-trip latency**: on localhost / low-latency it is essentially
+> smooth, but it can stutter on a slow or remote connection. Pro's *Rocket Virtual
+> Scroll* keeps windowing client-side (rAF / overscan / DOM recycling, no per-scroll
+> round-trip), so it stays smooth regardless of latency. Use core for
+> simple/occasional lists or low-latency setups; reach for Pro when you need large,
+> latency-independent, buttery-smooth virtualized lists.
+> (Note: *infinite scroll* is core via `data-on-intersect`; *virtual scroll* and
+> Rocket Virtual Scroll are different things — see the discussion that produced this.)

--- a/internal/handlers/datastar_recipes.go
+++ b/internal/handlers/datastar_recipes.go
@@ -194,6 +194,30 @@ func RecipeDialog(w http.ResponseWriter, r *http.Request) {
 	_ = sse.ExecuteScript("document.getElementById('recipe-dialog')?.showModal()")
 }
 
+// --- レシピ 9: 仮想スクロール（JS 不要・サーバ往復型）---
+// 可視範囲＋overscan の行だけを translateY 付きで差し替える。DOM 上の行は常に一定。
+
+func RecipeVRows(w http.ResponseWriter, r *http.Request) {
+	var sig struct {
+		Vstart int `json:"vstart"`
+	}
+	_ = datastar.ReadSignals(r, &sig)
+	start := sig.Vstart - components.RecipeVOverscan
+	if start < 0 {
+		start = 0
+	}
+	end := sig.Vstart + components.RecipeVVisible + components.RecipeVOverscan
+	if end > components.RecipeVTotal {
+		end = components.RecipeVTotal
+	}
+	sse := datastar.NewSSE(w, r)
+	_ = sse.PatchElementTempl(
+		components.RecipeVRows(start, end),
+		datastar.WithSelectorID("vrows"),
+		datastar.WithModeOuter(),
+	)
+}
+
 // --- リセット（インメモリ状態を初期化してリロード）---
 
 func RecipeReset(w http.ResponseWriter, r *http.Request) {

--- a/web/components/datastar_recipes.templ
+++ b/web/components/datastar_recipes.templ
@@ -101,6 +101,17 @@ templ DatastarRecipes(todos []RecipeTodo) {
 						<p class="mt-2 text-sm">selected: <span data-text="$choice"></span></p>
 					</div>
 				}
+				<!-- 9. 仮想スクロール（JS 不要・サーバ往復型）-->
+				@recipeCard("9. 仮想スクロール（JS 不要・サーバ往復）", "可視範囲＋overscan だけ描画し、スペーサーで全体高さを保つ。スクロールで開始 index を signal にし @get で窓を差し替える。DOM 上の行数は常に一定。", RecipeVScrollFront, RecipeVScrollBack) {
+					<div style="height:300px;overflow-y:auto;position:relative" class="border rounded bg-white"
+						data-signals:vstart="0"
+						data-on:scroll__throttle.100ms={ fmt.Sprintf("$vstart = Math.floor(evt.target.scrollTop / %d); @get('/datastar/recipes/api/vrows')", RecipeVRowH) }>
+						<div style={ fmt.Sprintf("height:%dpx;position:relative", RecipeVTotal*RecipeVRowH) }>
+							@RecipeVRows(0, RecipeVVisible+RecipeVOverscan)
+						</div>
+					</div>
+					<p class="text-xs text-gray-500 mt-1">全 { fmt.Sprint(RecipeVTotal) } 行。DevTools で #vrows 内の行数が一定のままスクロールできるのを確認できる。</p>
+				}
 			</div>
 		</body>
 	</html>
@@ -162,4 +173,14 @@ templ RecipeDialog() {
 		<p class="mb-4">これは SSE（PatchElementTempl）で挿入されたダイアログです。</p>
 		<button class="bg-gray-200 px-3 py-1 rounded" data-on:click="document.getElementById('recipe-dialog').close()">close</button>
 	</dialog>
+}
+
+// RecipeVRows は仮想スクロールの可視窓（start〜end）を translateY 付きで描画する。
+// サーバが #vrows を outer 置換することで、DOM 上の行は常に一定数に保たれる。
+templ RecipeVRows(start int, end int) {
+	<div id="vrows" style={ fmt.Sprintf("position:absolute;left:0;right:0;transform:translateY(%dpx)", start*RecipeVRowH) }>
+		for i := start; i < end; i++ {
+			<div style={ fmt.Sprintf("height:%dpx", RecipeVRowH) } class="px-3 border-b text-sm leading-[30px]">Row { fmt.Sprint(i + 1) }</div>
+		}
+	</div>
 }

--- a/web/components/recipe_data.go
+++ b/web/components/recipe_data.go
@@ -116,3 +116,33 @@ const RecipeDropdownFront = `<div data-signals:open="false" data-signals:choice=
   </div>
   <p>selected: <span data-text="$choice"></span></p>
 </div>`
+
+// 9. 仮想スクロール（JS 不要・サーバ往復型）。
+// 全行のうち可視範囲＋overscan だけを描画し、スペーサーで全体高さを保つ。
+const (
+	RecipeVTotal    = 1000 // 総行数
+	RecipeVRowH     = 30   // 行高(px)
+	RecipeVVisible  = 10   // 可視行数（コンテナ高さ 300px / 30px）
+	RecipeVOverscan = 5    // 可視範囲の上下に余分に描く行数
+)
+
+const RecipeVScrollFront = `<div style="height:300px;overflow-y:auto;position:relative"
+     data-signals:vstart="0"
+     data-on:scroll__throttle.100ms="$vstart = Math.floor(evt.target.scrollTop / 30); @get('/datastar/recipes/api/vrows')">
+  <!-- スペーサー: 全行ぶんの高さでスクロールバーを全件分に見せる -->
+  <div style="height:30000px;position:relative">
+    <!-- サーバが可視窓だけを translateY 付きで差し替える -->
+    <div id="vrows">...初期窓...</div>
+  </div>
+</div>`
+
+const RecipeVScrollBack = `func RecipeVRows(w http.ResponseWriter, r *http.Request) {
+    var sig struct{ Vstart int ` + "`json:\"vstart\"`" + ` }
+    datastar.ReadSignals(r, &sig)
+    start := max(sig.Vstart-overscan, 0)
+    end := min(sig.Vstart+visible+overscan, total)
+    sse := datastar.NewSSE(w, r)
+    // #vrows を outer 置換。窓は translateY(start*rowH) で正しい位置に。
+    sse.PatchElementTempl(RecipeVRows(start, end),
+        datastar.WithSelectorID("vrows"), datastar.WithModeOuter())
+}`


### PR DESCRIPTION
## 概要
無限スクロールは要素が増え続けて DOM が肥大化する問題があるため、可視範囲＋overscan だけを描画する**仮想スクロール**をレシピ⑨として追加。Pro の *Rocket Virtual Scroll* とは別物で、**core でも `data-*` ＋ サーバ往復のみ（JS 不要）**で実装できることを示すお手本。

## 仕組み
- `data-on:scroll__throttle.100ms` で `scrollTop` から開始 index を signal 化 → `@get`
- サーバが可視窓だけを `translateY` 付きで `PatchElements`(outer 置換)
- スペーサーで全体高さを保つ → スクロールバーは全件分、**DOM 上の行は窓分だけ**

## guide 更新
- §12 レシピ一覧に追記
- **core vs Pro の使い分け**: スムーズさは往復レイテンシ依存（localhost では滑らか、リモート/低速回線ではカクつきうる）。Pro はクライアント完結でレイテンシ非依存。infinite scroll(core, `data-on-intersect`) と virtual scroll は別物、という整理も明記

## 検証
- 全 1000 行で Claude in Chrome 実機確認（スクロールで Row が追従、DOM の行数は一定のまま）
- `make build` / `make vet` / `make lint`(0 issues) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)