### PR TITLE
仮想スクロールの通信最適化（窓変化時のみ＋trailing）と注記整理

### DIFF
--- a/docs/datastar/datastar-llm-guide.md
+++ b/docs/datastar/datastar-llm-guide.md
@@ -556,12 +556,21 @@ live search, indicator, polling, dialog, dropdown, and a **JS-free virtual scrol
 > of rows by re-fetching the visible window on scroll (`data-on:scroll__throttle`
 > sets a start-index signal → `@get` → server patches only that window with a
 > `translateY` offset; a spacer holds the full height). It avoids infinite-scroll's
-> DOM bloat, but because it re-fetches the window on scroll, its smoothness
-> **depends on round-trip latency**: on localhost / low-latency it is essentially
-> smooth, but it can stutter on a slow or remote connection. Pro's *Rocket Virtual
-> Scroll* keeps windowing client-side (rAF / overscan / DOM recycling, no per-scroll
-> round-trip), so it stays smooth regardless of latency. Use core for
-> simple/occasional lists or low-latency setups; reach for Pro when you need large,
-> latency-independent, buttery-smooth virtualized lists.
+> DOM bloat. It re-fetches the window on scroll, so smoothness depends on round-trip
+> latency — but in practice it holds up well: smooth on localhost, and **verified
+> comfortably usable on a typical VPS** (`__throttle` caps round-trips and overscan
+> hides the gaps). Noticeable stutter only shows on high-latency links (distant
+> servers, flaky mobile). Pro's *Rocket Virtual Scroll* keeps windowing client-side
+> (rAF / overscan / DOM recycling, no per-scroll round-trip), so it stays smooth even
+> under high latency. Use core for most cases; reach for Pro for very large lists that
+> must stay buttery-smooth on slow links.
+>
+> **Fixed row height is required.** The core recipe assumes every row is the same
+> height (`scrollTop / rowH` → index, spacer = `rows * rowH`, `translateY(start * rowH)`).
+> Variable heights break all of this: you'd need cumulative offsets (prefix sums) +
+> binary search to map scrollTop→index, and measure-then-correct after render — not
+> feasible with `data-*` alone (needs real JS, and gets complex fast). Use this for
+> uniform rows (tables, fixed-size cards); for variable-height content (chat, wrapping
+> text, mixed media) use pagination/infinite-scroll or Pro.
 > (Note: *infinite scroll* is core via `data-on-intersect`; *virtual scroll* and
 > Rocket Virtual Scroll are different things — see the discussion that produced this.)

--- a/web/components/datastar_recipes.templ
+++ b/web/components/datastar_recipes.templ
@@ -102,10 +102,10 @@ templ DatastarRecipes(todos []RecipeTodo) {
 					</div>
 				}
 				<!-- 9. 仮想スクロール（JS 不要・サーバ往復型）-->
-				@recipeCard("9. 仮想スクロール（JS 不要・サーバ往復）", "可視範囲＋overscan だけ描画し、スペーサーで全体高さを保つ。スクロールで開始 index を signal にし @get で窓を差し替える。DOM 上の行数は常に一定。", RecipeVScrollFront, RecipeVScrollBack) {
+				@recipeCard("9. 仮想スクロール（JS 不要・サーバ往復）", "可視範囲＋overscan だけ描画し、スペーサーで全体高さを保つ。スクロールで開始 index を signal にし @get で窓を差し替える。DOM 上の行数は常に一定。※行高固定が前提（可変高さは非対応）。", RecipeVScrollFront, RecipeVScrollBack) {
 					<div style="height:300px;overflow-y:auto;position:relative" class="border rounded bg-white"
 						data-signals:vstart="0"
-						data-on:scroll__throttle.100ms={ fmt.Sprintf("$vstart = Math.floor(evt.target.scrollTop / %d); @get('/datastar/recipes/api/vrows')", RecipeVRowH) }>
+						data-on:scroll__throttle.100ms.trailing={ fmt.Sprintf("Math.floor(evt.target.scrollTop / %d) !== $vstart && ($vstart = Math.floor(evt.target.scrollTop / %d), @get('/datastar/recipes/api/vrows'))", RecipeVRowH, RecipeVRowH) }>
 						<div style={ fmt.Sprintf("height:%dpx;position:relative", RecipeVTotal*RecipeVRowH) }>
 							@RecipeVRows(0, RecipeVVisible+RecipeVOverscan)
 						</div>

--- a/web/components/recipe_data.go
+++ b/web/components/recipe_data.go
@@ -128,7 +128,11 @@ const (
 
 const RecipeVScrollFront = `<div style="height:300px;overflow-y:auto;position:relative"
      data-signals:vstart="0"
-     data-on:scroll__throttle.100ms="$vstart = Math.floor(evt.target.scrollTop / 30); @get('/datastar/recipes/api/vrows')">
+     data-on:scroll__throttle.100ms.trailing="
+       Math.floor(evt.target.scrollTop / 30) !== $vstart &&
+       ($vstart = Math.floor(evt.target.scrollTop / 30), @get('/datastar/recipes/api/vrows'))">
+  <!-- 窓(vstart)が変わった時だけ @get（無駄な再取得を避ける）。
+       .trailing でスクロール停止時の最終窓も確実に取得する。 -->
   <!-- スペーサー: 全行ぶんの高さでスクロールバーを全件分に見せる -->
   <div style="height:30000px;position:relative">
     <!-- サーバが可視窓だけを translateY 付きで差し替える -->


### PR DESCRIPTION
## 概要
レシピ⑨（仮想スクロール）の通信を最適化し、関連する注記を整理。

## 通信最適化
- **窓変化時のみ通信**: `$vstart`（窓の開始行）が変わったときだけ `@get`。同じ窓の無駄な再取得を解消
  - 実機検証: 33 行スクロールで `/vrows` リクエストが **1 回だけ**
- **`.trailing` 追加**: スクロール停止時の最終窓を確実に取得（停止位置の窓が来ず古い窓が残る問題を修正。実機で再現・修正を確認）

## 注記整理（guide §12 + レシピ説明文）
- **スムーズさはレイテンシ依存**: VPS で実用的と実測、カクつくのは高レイテンシ環境のみ（Pro はレイテンシ非依存）
- **行高固定が前提**: 可変高さは累積高さ（prefix sum）＋二分探索＋測定補正が必要で core では非現実的。均一行（テーブル/固定カード）向け、可変はページネーション/Pro

## 検証
- 実機（Claude in Chrome + network 監視）で通信回数・最終窓・表示を確認
- `make build` / `make vet` / `make lint`(0 issues) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)