### PR TITLE
レシピ集に「ダイアログ編集（遷移なし・PRG の代替）」を追加

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -180,6 +180,8 @@ func main() {
 	r.Get("/datastar/recipes/api/tick", handlers.RecipeTick)
 	r.Get("/datastar/recipes/api/dialog", handlers.RecipeDialog)
 	r.Get("/datastar/recipes/api/vrows", handlers.RecipeVRows)
+	r.Get("/datastar/recipes/api/items/{id}/edit", handlers.RecipeItemEdit)
+	r.Put("/datastar/recipes/api/items/{id}", handlers.RecipeItemUpdate)
 	r.Post("/datastar/recipes/api/reset", handlers.RecipeReset)
 
 	// MagicLink handlers (net/http ベース)

--- a/docs/datastar/datastar-llm-guide.md
+++ b/docs/datastar/datastar-llm-guide.md
@@ -548,8 +548,10 @@ These options map 1:1 to the SSE `selector` / `mode` / `useViewTransition` data 
 ### Live recipes
 A runnable, source-annotated recipe set is served at **`/datastar/recipes`** (public,
 DB-free in-memory demos): two-way bind, server round-trip counter, in-memory TODO CRUD,
-live search, indicator, polling, dialog, dropdown, and a **JS-free virtual scroll**
-(server round-trip windowing). Source to copy from:
+live search, indicator, polling, dialog, dropdown, a **JS-free virtual scroll**
+(server round-trip windowing), and **dialog edit with no navigation/reload** (the
+SPA-style alternative to PRG: edit in a dialog → `@put` → server patches just that row
+and closes the dialog — no page transition, no reload). Source to copy from:
 `web/components/datastar_recipes.templ` + `internal/handlers/datastar_recipes.go`.
 
 > **Virtual scroll — core vs Pro.** The core recipe keeps the DOM to a fixed number

--- a/internal/handlers/datastar_recipes.go
+++ b/internal/handlers/datastar_recipes.go
@@ -29,6 +29,7 @@ type recipeStore struct {
 	counter int
 	todos   []components.RecipeTodo
 	nextID  int
+	items   []components.RecipeItem
 }
 
 var recipeState = &recipeStore{}
@@ -75,6 +76,53 @@ func (s *recipeStore) reset() {
 	defer s.mu.Unlock()
 	s.counter = 0
 	s.todos = nil
+	s.items = nil
+}
+
+// items はダイアログ編集デモ用。初回アクセス時に seed し、全訪問者で共有、
+// reset で初期化される。
+func (s *recipeStore) seedItemsLocked() {
+	if len(s.items) == 0 {
+		s.items = []components.RecipeItem{
+			{ID: 1, Name: "Alpha"},
+			{ID: 2, Name: "Bravo"},
+			{ID: 3, Name: "Charlie"},
+		}
+	}
+}
+
+func (s *recipeStore) snapshotItems() []components.RecipeItem {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seedItemsLocked()
+	out := make([]components.RecipeItem, len(s.items))
+	copy(out, s.items)
+	return out
+}
+
+func (s *recipeStore) item(id int) (components.RecipeItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seedItemsLocked()
+	for _, it := range s.items {
+		if it.ID == id {
+			return it, true
+		}
+	}
+	return components.RecipeItem{}, false
+}
+
+func (s *recipeStore) updateItem(id int, name string) (components.RecipeItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seedItemsLocked()
+	for i := range s.items {
+		if s.items[i].ID == id {
+			s.items[i].Name = name
+			return s.items[i], true
+		}
+	}
+	return components.RecipeItem{}, false
 }
 
 // recipeFruits はライブ検索デモ用の固定リスト。
@@ -87,7 +135,7 @@ var recipeFruits = []string{
 func DatastarRecipesPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	_ = components.DatastarRecipes(recipeState.snapshotTodos()).Render(r.Context(), w)
+	_ = components.DatastarRecipes(recipeState.snapshotTodos(), recipeState.snapshotItems()).Render(r.Context(), w)
 }
 
 // --- レシピ 2: サーバ往復カウンタ（@post → MarshalAndPatchSignals）---
@@ -216,6 +264,55 @@ func RecipeVRows(w http.ResponseWriter, r *http.Request) {
 		datastar.WithSelectorID("vrows"),
 		datastar.WithModeOuter(),
 	)
+}
+
+// --- レシピ 10: ダイアログ編集（遷移なし・PRG の代替）---
+// 行の edit → @get でダイアログ表示。保存(@put)で該当行だけ patch しダイアログを閉じる。
+// ページ遷移も reload もしない。
+
+func RecipeItemEdit(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	item, ok := recipeState.item(id)
+	if !ok {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	sse := datastar.NewSSE(w, r)
+	_ = sse.PatchElementTempl(
+		components.RecipeItemEditDialog(item),
+		datastar.WithSelectorID("recipe-item-dialog-container"),
+		datastar.WithModeInner(),
+	)
+	_ = sse.ExecuteScript("document.getElementById('recipe-item-dialog')?.showModal()")
+}
+
+func RecipeItemUpdate(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	var sig struct {
+		Editname string `json:"editname"`
+	}
+	_ = datastar.ReadSignals(r, &sig)
+	item, ok := recipeState.updateItem(id, strings.TrimSpace(sig.Editname))
+	if !ok {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	sse := datastar.NewSSE(w, r)
+	// 該当行だけ outer 置換。reload も遷移もしない（Datastar 流の編集）。
+	_ = sse.PatchElementTempl(
+		components.RecipeItemRow(item),
+		datastar.WithSelectorID(fmt.Sprintf("item-%d", id)),
+		datastar.WithModeOuter(),
+	)
+	_ = sse.ExecuteScript("document.getElementById('recipe-item-dialog')?.close()")
 }
 
 // --- リセット（インメモリ状態を初期化してリロード）---

--- a/web/components/datastar_recipes.templ
+++ b/web/components/datastar_recipes.templ
@@ -11,7 +11,7 @@ import (
 // 見せるお手本レシピ集（/datastar/recipes、認証不要・本番公開）。
 // バックエンドは internal/handlers/datastar_recipes.go（DB 非依存のインメモリ）。
 
-templ DatastarRecipes(todos []RecipeTodo) {
+templ DatastarRecipes(todos []RecipeTodo, items []RecipeItem) {
 	<!DOCTYPE html>
 	<html lang="ja">
 		@layouts.Head("Datastar Recipes") {
@@ -112,6 +112,15 @@ templ DatastarRecipes(todos []RecipeTodo) {
 					</div>
 					<p class="text-xs text-gray-500 mt-1">全 { fmt.Sprint(RecipeVTotal) } 行。DevTools で #vrows 内の行数が一定のままスクロールできるのを確認できる。</p>
 				}
+				<!-- 10. ダイアログ編集（遷移なし・PRG の代替）-->
+				@recipeCard("10. ダイアログ編集（遷移なし・PRG の代替）", "行の edit → @get でダイアログ表示。保存で該当行だけ patch しダイアログを閉じる。ページ遷移も reload もしない（admin の「保存後 reload」を置き換える Datastar 流の推奨形）。", RecipeItemEditFront, RecipeItemEditBack) {
+					<div>
+						<ul id="recipe-items" class="divide-y border rounded">
+							@RecipeItemList(items)
+						</ul>
+						<div id="recipe-item-dialog-container"></div>
+					</div>
+				}
 			</div>
 		</body>
 	</html>
@@ -183,4 +192,33 @@ templ RecipeVRows(start int, end int) {
 			<div style={ fmt.Sprintf("height:%dpx", RecipeVRowH) } class="px-3 border-b text-sm leading-[30px]">Row { fmt.Sprint(i + 1) }</div>
 		}
 	</div>
+}
+
+// RecipeItemList / RecipeItemRow / RecipeItemEditDialog はダイアログ編集（遷移なし）用。
+templ RecipeItemList(items []RecipeItem) {
+	for _, it := range items {
+		@RecipeItemRow(it)
+	}
+}
+
+// RecipeItemRow は1行。保存時にサーバがこの行だけを outer 置換する（id で特定）。
+templ RecipeItemRow(item RecipeItem) {
+	<li id={ fmt.Sprintf("item-%d", item.ID) } class="flex items-center gap-2 px-3 py-2">
+		<span class="flex-1">{ item.Name }</span>
+		<button class="text-blue-600 text-sm" data-on:click={ fmt.Sprintf("@get('/datastar/recipes/api/items/%d/edit')", item.ID) }>edit</button>
+	</li>
+}
+
+// RecipeItemEditDialog は @get で挿入される編集ダイアログ。signal は小文字 editname。
+templ RecipeItemEditDialog(item RecipeItem) {
+	<dialog id="recipe-item-dialog" data-signals={ fmt.Sprintf("{editname: '%s'}", item.Name) } class="m-auto rounded-lg p-6 backdrop:bg-black/30">
+		<form data-on:submit__prevent={ fmt.Sprintf("@put('/datastar/recipes/api/items/%d')", item.ID) } class="space-y-3">
+			<p class="text-sm text-gray-500">Edit item #{ fmt.Sprint(item.ID) }</p>
+			<input class="border px-2 py-1 rounded w-full" data-bind:editname/>
+			<div class="flex gap-2 justify-end">
+				<button type="button" class="bg-gray-200 px-3 py-1 rounded" data-on:click="document.getElementById('recipe-item-dialog').close()">cancel</button>
+				<button class="bg-blue-600 text-white px-3 py-1 rounded">save</button>
+			</div>
+		</form>
+	</dialog>
 }

--- a/web/components/recipe_data.go
+++ b/web/components/recipe_data.go
@@ -10,6 +10,12 @@ type RecipeTodo struct {
 	Text string
 }
 
+// RecipeItem はダイアログ編集デモ（遷移なし）の1項目。
+type RecipeItem struct {
+	ID   int
+	Name string
+}
+
 // 1. 双方向バインド（フロントのみ）
 const RecipeBindFront = `<div data-signals:name="''">
   <input data-bind:name placeholder="your name"/>
@@ -149,4 +155,43 @@ const RecipeVScrollBack = `func RecipeVRows(w http.ResponseWriter, r *http.Reque
     // #vrows を outer 置換。窓は translateY(start*rowH) で正しい位置に。
     sse.PatchElementTempl(RecipeVRows(start, end),
         datastar.WithSelectorID("vrows"), datastar.WithModeOuter())
+}`
+
+// 10. ダイアログ編集（遷移なし・PRG の代替）。
+// 行の edit → @get でダイアログ表示。保存(@put)で該当行だけ patch しダイアログを閉じる。
+// ページ遷移も reload もしない。
+const RecipeItemEditFront = `<ul id="recipe-items">
+  <li id="item-1" class="flex gap-2">
+    <span>Alpha</span>
+    <button data-on:click="@get('/datastar/recipes/api/items/1/edit')">edit</button>
+  </li>
+  <!-- ...other rows... -->
+</ul>
+<div id="recipe-item-dialog-container"></div>
+
+<!-- @get で挿入される編集ダイアログ（signal は小文字 editname）: -->
+<dialog id="recipe-item-dialog" data-signals="{editname: 'Alpha'}">
+  <form data-on:submit__prevent="@put('/datastar/recipes/api/items/1')">
+    <input data-bind:editname/>
+    <button>save</button>
+  </form>
+</dialog>`
+
+const RecipeItemEditBack = `// 編集ダイアログを開く（@get）
+func RecipeItemEdit(w http.ResponseWriter, r *http.Request) {
+    item := store.item(id)
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElementTempl(RecipeItemEditDialog(item),
+        datastar.WithSelectorID("recipe-item-dialog-container"), datastar.WithModeInner())
+    sse.ExecuteScript("document.getElementById('recipe-item-dialog').showModal()")
+}
+// 保存（@put）— 該当行だけ patch、reload も遷移もしない
+func RecipeItemUpdate(w http.ResponseWriter, r *http.Request) {
+    var sig struct{ Editname string ` + "`json:\"editname\"`" + ` }
+    datastar.ReadSignals(r, &sig)
+    store.updateItem(id, sig.Editname)
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElementTempl(RecipeItemRow(store.item(id)),
+        datastar.WithSelectorID(fmt.Sprintf("item-%d", id)), datastar.WithModeOuter())
+    sse.ExecuteScript("document.getElementById('recipe-item-dialog').close()")
 }`


### PR DESCRIPTION
## 概要
PRG（送信→リダイレクト→GET）の代替として、**ダイアログで編集 → 該当行だけ patch → reload なし**の Datastar 流編集パターンをレシピ⑩として追加。admin/projects の「保存後 reload」を置き換える推奨形。

## 動作
- 行の `edit` → `@get` でダイアログを挿入（現在値入り）＋ `showModal()`
- 保存 `@put` → サーバが該当行だけ `PatchElementTempl`(outer, `WithSelectorID("item-N")`) で差し替え ＋ ダイアログを `close()`
- **ページ遷移も reload もなし**

## 変更
| ファイル | 内容 |
|---|---|
| `internal/handlers/datastar_recipes.go` | インメモリ items ストア（seed/共有/reset）＋ `RecipeItemEdit`/`RecipeItemUpdate` |
| `web/components/datastar_recipes.templ` | `RecipeItemList`/`Row`/`EditDialog`、デモ、`DatastarRecipes` に items 引数 |
| `web/components/recipe_data.go` | `RecipeItem` 型＋お手本ソース |
| `cmd/server/main.go` | `@get .../items/{id}/edit`、`@put .../items/{id}` ルート |
| `docs/datastar/datastar-llm-guide.md` | §12 レシピ一覧に追記 |

## 検証
- 実機（Claude in Chrome）で確認: 編集 → 該当行だけ更新、他の行・仮想スクロールはそのまま（reload されていない）
- `make build` / `make vet` / `make lint`(0 issues) 通過

これは「編集はダイアログ patch 主体」へ方針転換する第一歩。次段で `CLAUDE.md` の方針更新と既存ハンドラの patch 化を検討予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)