### PR TITLE
admin users の編集・追加・削除を patch 化（reload 廃止）+ ダイアログ中央

### DIFF
--- a/internal/handlers/sse_admin.go
+++ b/internal/handlers/sse_admin.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -33,35 +34,46 @@ func (h *AdminSSEHandler) CreateUserDialogSSE(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if err := h.createUser(r.Context(), signals.NewName, signals.NewEmail, signals.NewRole); err != nil {
+	user, err := h.createUser(r.Context(), signals.NewName, signals.NewEmail, signals.NewRole)
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	sse := newSSE(w, r)
-	sse.ExecuteScript("document.getElementById('user-add-dialog')?.close(); window.location.reload()")
+	// 新しいカードを一覧末尾に追加する（reload しない）。
+	if err := sse.PatchElementTempl(
+		components.AdminUserCard(user),
+		datastar.WithSelectorID("users-table"),
+		datastar.WithModeAppend(),
+	); err != nil {
+		logger.Error("SSE PatchElementTempl failed", "error", err)
+		return
+	}
+	sse.ExecuteScript("document.getElementById('user-add-dialog')?.close()")
 }
 
-func (h *AdminSSEHandler) createUser(ctx context.Context, name, email, role string) error {
+func (h *AdminSSEHandler) createUser(ctx context.Context, name, email, role string) (database.User, error) {
 	if name == "" || email == "" || role == "" {
-		return http.ErrAbortHandler
+		return database.User{}, http.ErrAbortHandler
 	}
 
 	if !roles.IsValid(role) {
-		return http.ErrAbortHandler
+		return database.User{}, http.ErrAbortHandler
 	}
 
-	if _, err := h.Queries.CreateUser(ctx, database.CreateUserParams{
+	user, err := h.Queries.CreateUser(ctx, database.CreateUserParams{
 		Email:    email,
 		Name:     name,
 		Role:     role,
 		IsActive: true,
-	}); err != nil {
+	})
+	if err != nil {
 		logger.Error("ユーザー作成に失敗", "error", err, "email", email)
-		return err
+		return database.User{}, err
 	}
 
-	return nil
+	return user, nil
 }
 
 func (h *AdminSSEHandler) EditUserDialogSSE(w http.ResponseWriter, r *http.Request) {
@@ -122,8 +134,23 @@ func (h *AdminSSEHandler) UpdateUserSSE(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// 更新後のユーザーを取得し、該当カードだけを patch する（reload しない）。
+	user, err := h.Queries.GetUserByID(r.Context(), id)
+	if err != nil {
+		http.Error(w, "ユーザーが見つかりません", http.StatusNotFound)
+		return
+	}
+
 	sse := newSSE(w, r)
-	sse.ExecuteScript("document.getElementById('user-edit-dialog')?.close(); window.location.reload()")
+	if err := sse.PatchElementTempl(
+		components.AdminUserCard(user),
+		datastar.WithSelectorID(fmt.Sprintf("user-%d", id)),
+		datastar.WithModeOuter(),
+	); err != nil {
+		logger.Error("SSE PatchElementTempl failed", "error", err)
+		return
+	}
+	sse.ExecuteScript("document.getElementById('user-edit-dialog')?.close()")
 }
 
 func (h *AdminSSEHandler) DeleteUserSSE(w http.ResponseWriter, r *http.Request) {
@@ -146,5 +173,8 @@ func (h *AdminSSEHandler) DeleteUserSSE(w http.ResponseWriter, r *http.Request) 
 	}
 
 	sse := newSSE(w, r)
-	sse.ExecuteScript("document.getElementById('user-edit-dialog')?.close(); window.location.reload()")
+	// 該当カードを除去する（reload しない）。
+	if err := sse.RemoveElementByID(fmt.Sprintf("user-%d", id)); err != nil {
+		logger.Error("SSE RemoveElementByID failed", "error", err)
+	}
 }

--- a/internal/integration/admin_crud_test.go
+++ b/internal/integration/admin_crud_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -105,6 +106,38 @@ func TestAdminCRUD_UpdateUser_Deactivate(t *testing.T) {
 	}
 }
 
+// TestAdminCRUD_UpdateUser_PatchesCardNoReload は、編集保存が reload ではなく
+// 該当カードだけの patch になっていることを担保する（UI 更新方針の回帰防止）。
+func TestAdminCRUD_UpdateUser_PatchesCardNoReload(t *testing.T) {
+	conn := SetupTestDB(t)
+	e := SetupTestServer(t, conn)
+	seed := SeedTestData(t, conn)
+
+	targetID := seed.ViewerUser.ID
+
+	rec := DoSSERequest(e, http.MethodPut, sprintf("/api/sse/admin/users/%d", targetID),
+		&seed.AdminUser,
+		`{"editName":"PatchedName","editRole":"editor","editStatus":"active"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ステータスコード = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, "location.reload") {
+		t.Errorf("reload してはいけない（patch 化されていない）。body: %s", body)
+	}
+	if !strings.Contains(body, "datastar-patch-elements") {
+		t.Errorf("datastar-patch-elements イベントが無い。body: %s", body)
+	}
+	if !strings.Contains(body, sprintf("user-%d", targetID)) {
+		t.Errorf("該当カード id (user-%d) が patch に含まれない。body: %s", targetID, body)
+	}
+	if !strings.Contains(body, "PatchedName") {
+		t.Errorf("更新後の名前が patch に含まれない。body: %s", body)
+	}
+}
+
 func TestAdminCRUD_DeleteUser(t *testing.T) {
 	conn := SetupTestDB(t)
 	e := SetupTestServer(t, conn)
@@ -142,5 +175,57 @@ func TestAdminCRUD_DeleteUser_PreventSelfDeletion(t *testing.T) {
 	_, err := q.GetUserByID(t.Context(), seed.AdminUser.ID)
 	if err != nil {
 		t.Error("自分自身が削除されてしまった")
+	}
+}
+
+// TestAdminCRUD_CreateUser_AppendsCardNoReload は、追加が reload ではなく
+// 新カードの append になっていることを担保する。
+func TestAdminCRUD_CreateUser_AppendsCardNoReload(t *testing.T) {
+	conn := SetupTestDB(t)
+	e := SetupTestServer(t, conn)
+	seed := SeedTestData(t, conn)
+
+	rec := DoSSERequest(e, http.MethodPost, "/api/sse/admin/users/create",
+		&seed.AdminUser,
+		`{"newName":"AppendedUser","newEmail":"appended@test.com","newRole":"editor"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ステータスコード = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, "location.reload") {
+		t.Errorf("reload してはいけない。body: %s", body)
+	}
+	if !strings.Contains(body, "datastar-patch-elements") {
+		t.Errorf("datastar-patch-elements が無い。body: %s", body)
+	}
+	if !strings.Contains(body, "AppendedUser") {
+		t.Errorf("新ユーザーのカードが patch に含まれない。body: %s", body)
+	}
+}
+
+// TestAdminCRUD_DeleteUser_RemovesCardNoReload は、削除が reload ではなく
+// 該当カードの除去になっていることを担保する。
+func TestAdminCRUD_DeleteUser_RemovesCardNoReload(t *testing.T) {
+	conn := SetupTestDB(t)
+	e := SetupTestServer(t, conn)
+	seed := SeedTestData(t, conn)
+
+	targetID := seed.DeletableUser.ID
+
+	rec := DoSSERequest(e, http.MethodDelete, sprintf("/api/sse/admin/users/%d", targetID),
+		&seed.AdminUser, "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ステータスコード = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, "location.reload") {
+		t.Errorf("reload してはいけない。body: %s", body)
+	}
+	if !strings.Contains(body, sprintf("user-%d", targetID)) {
+		t.Errorf("削除対象カード id (user-%d) が patch に含まれない。body: %s", targetID, body)
 	}
 }

--- a/web/components/admin_users_list.templ
+++ b/web/components/admin_users_list.templ
@@ -74,28 +74,36 @@ templ AdminUserEditDialog(user database.User) {
 templ adminUsersCards(users []database.User) {
     <div id="users-table" class="space-y-3">
         for _, user := range users {
-            @SectionCard() {
-                <div class="flex items-start justify-between">
-                    <div class="min-w-0 flex-1">
-                        <div class="flex items-center gap-2 flex-wrap">
-                            <span class="text-sm font-medium text-gray-900">{ user.Name }</span>
-                            @RoleBadge(user.Role)
-                            @StatusBadge(user.IsActive)
-                        </div>
-                        <p class="mt-1 text-sm text-gray-500 truncate">{ user.Email }</p>
+            @AdminUserCard(user)
+        }
+    </div>
+}
+
+// AdminUserCard は1ユーザーのカード。編集保存時にサーバがこの要素だけを
+// id (user-N) で outer 置換する（reload しない）。
+templ AdminUserCard(user database.User) {
+    <div id={ fmt.Sprintf("user-%d", user.ID) }>
+        @SectionCard() {
+            <div class="flex items-start justify-between">
+                <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2 flex-wrap">
+                        <span class="text-sm font-medium text-gray-900">{ user.Name }</span>
+                        @RoleBadge(user.Role)
+                        @StatusBadge(user.IsActive)
                     </div>
-                    <div class="flex items-center gap-3 ml-4 flex-shrink-0">
-                        <button
-                            class="text-indigo-600 hover:text-indigo-900 text-sm font-medium"
-                            data-on:click={ fmt.Sprintf("@get('/api/sse/admin/users/%d/edit')", user.ID) }
-                        >編集</button>
-                        <button
-                            class="text-red-600 hover:text-red-800 text-sm font-medium"
-                            data-on:click={ fmt.Sprintf("confirm('本当にこのユーザーを削除しますか？') && @delete('/api/sse/admin/users/%d')", user.ID) }
-                        >削除</button>
-                    </div>
+                    <p class="mt-1 text-sm text-gray-500 truncate">{ user.Email }</p>
                 </div>
-            }
+                <div class="flex items-center gap-3 ml-4 flex-shrink-0">
+                    <button
+                        class="text-indigo-600 hover:text-indigo-900 text-sm font-medium"
+                        data-on:click={ fmt.Sprintf("@get('/api/sse/admin/users/%d/edit')", user.ID) }
+                    >編集</button>
+                    <button
+                        class="text-red-600 hover:text-red-800 text-sm font-medium"
+                        data-on:click={ fmt.Sprintf("confirm('本当にこのユーザーを削除しますか？') && @delete('/api/sse/admin/users/%d')", user.ID) }
+                    >削除</button>
+                </div>
+            </div>
         }
     </div>
 }

--- a/web/components/ui_page.templ
+++ b/web/components/ui_page.templ
@@ -39,7 +39,7 @@ templ SectionCardTitle(title string, description string) {
 templ Dialog(id string, attrs templ.Attributes) {
     <dialog id={ id }
         onclick="if(event.target===this)this.close()"
-        class="mx-auto w-[calc(100%-2rem)] max-w-md rounded-xl border border-gray-200 bg-white p-6 shadow-xl backdrop:bg-gray-900/50"
+        class="m-auto w-[calc(100%-2rem)] max-w-md rounded-xl border border-gray-200 bg-white p-6 shadow-xl backdrop:bg-gray-900/50"
         { attrs... }
     >
         { children... }


### PR DESCRIPTION
## 概要
UI 更新方針（編集はダイアログ patch 主体）に沿って、admin users 画面を完全に patch 化。「保存後 `window.location.reload()`」をやめ、該当部分だけ SSE で更新する。

## 変更
| 操作 | Before | After |
|---|---|---|
| 編集保存 | reload | 該当カードを `id=user-N` で `PatchElementTempl`(outer) 置換 |
| 追加 | reload | 新カードを一覧末尾に `WithModeAppend` |
| 削除 | reload | `RemoveElementByID("user-N")` で除去 |
| ダイアログ位置 | 上に張り付き | `Dialog` を `mx-auto`→`m-auto` で中央（既存バグ修正、全ダイアログに波及） |

- `AdminUserCard`（`id=user-N`）を切り出して patch 対象を特定
- `createUser` が作成ユーザーを返すよう変更（append 用）

## 検証
- 回帰防止テスト3本追加（編集/追加/削除すべて「reload しない・patch する」を assert）→ PASS
- `make build`/`vet`/`lint`(0 issues)/全テスト(FAIL 0) 通過
- 実機（admin ログイン）で編集/追加/削除すべて reload なし・ダイアログ中央を確認

## 補足
これは「既存ハンドラの reload を patch 化」シリーズの第一弾。後続で projects / profile / maintenance も patch 化予定。タグ（v0.6.0）はシリーズ完了時にまとめて打つ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)