### PR TITLE
maintenance と profile を patch 化（reload 廃止）

### DIFF
--- a/internal/handlers/admin_maintenance.go
+++ b/internal/handlers/admin_maintenance.go
@@ -7,6 +7,7 @@ import (
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/logger"
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/maintenance"
 	"github.com/naozine/project_crud_with_auth_tmpl/web/components"
+	"github.com/starfederation/datastar-go/datastar"
 )
 
 type MaintenanceHandler struct {
@@ -23,8 +24,8 @@ func (h *MaintenanceHandler) Page(w http.ResponseWriter, r *http.Request) {
 	renderShell(w, r, "メンテナンスモード", components.AdminMaintenance(enabled))
 }
 
-// ToggleSSE は現在のメンテモードを反転させて、画面リロードを指示する。
-// Datastar 経由 (POST /api/sse/admin/maintenance/toggle)。
+// ToggleSSE は現在のメンテモードを反転させ、状態パネルだけを patch する。
+// Datastar 経由 (POST /api/sse/admin/maintenance/toggle)。reload しない。
 func (h *MaintenanceHandler) ToggleSSE(w http.ResponseWriter, r *http.Request) {
 	cur := maintenance.IsEnabled(r.Context(), h.Queries)
 	if err := maintenance.SetEnabled(r.Context(), h.Queries, !cur); err != nil {
@@ -34,5 +35,12 @@ func (h *MaintenanceHandler) ToggleSSE(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sse := newSSE(w, r)
-	sse.ExecuteScript("window.location.reload()")
+	// 状態パネルだけを差し替える（reload しない）。
+	if err := sse.PatchElementTempl(
+		components.AdminMaintenancePanel(!cur),
+		datastar.WithSelectorID("maintenance-panel"),
+		datastar.WithModeOuter(),
+	); err != nil {
+		logger.Error("SSE PatchElementTempl failed", "error", err)
+	}
 }

--- a/internal/handlers/sse_profile.go
+++ b/internal/handlers/sse_profile.go
@@ -7,6 +7,7 @@ import (
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/appcontext"
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/database"
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/logger"
+	"github.com/naozine/project_crud_with_auth_tmpl/web/components"
 	"github.com/starfederation/datastar-go/datastar"
 )
 
@@ -53,7 +54,9 @@ func (h *ProfileSSEHandler) UpdateProfileSSE(w http.ResponseWriter, r *http.Requ
 	}
 
 	sse := newSSE(w, r)
-	sse.ExecuteScript("window.location.reload()")
+	// シェルは email 表示で名前を出さないため、保存後は originalName を更新して
+	// 保存ボタンを disabled に戻すだけでよい（reload しない）。
+	_ = sse.MarshalAndPatchSignals(map[string]any{"originalName": signals.ProfileName})
 }
 
 func (h *ProfileSSEHandler) DeletePasskeysSSE(w http.ResponseWriter, r *http.Request) {
@@ -73,5 +76,12 @@ func (h *ProfileSSEHandler) DeletePasskeysSSE(w http.ResponseWriter, r *http.Req
 	}
 
 	sse := newSSE(w, r)
-	sse.ExecuteScript("window.location.reload()")
+	// セキュリティカードだけを未登録状態に差し替える（reload しない）。
+	if err := sse.PatchElementTempl(
+		components.ProfileSecurityCard(email, false),
+		datastar.WithSelectorID("profile-security"),
+		datastar.WithModeOuter(),
+	); err != nil {
+		logger.Error("SSE PatchElementTempl failed", "error", err)
+	}
 }

--- a/internal/integration/maintenance_test.go
+++ b/internal/integration/maintenance_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"bytes"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/database"
@@ -75,6 +76,30 @@ func TestMaintenance_ToggleSSE(t *testing.T) {
 	rec = DoSSERequest(e, http.MethodPost, "/api/sse/admin/maintenance/toggle", nil, "")
 	if rec.Code != http.StatusSeeOther {
 		t.Errorf("unauth: got %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+}
+
+// TestMaintenance_ToggleSSE_PatchesPanelNoReload は、トグルが reload ではなく
+// 状態パネルの patch になっていることを担保する。
+func TestMaintenance_ToggleSSE_PatchesPanelNoReload(t *testing.T) {
+	conn := SetupTestDB(t)
+	e := SetupTestServer(t, conn)
+	seed := SeedTestData(t, conn)
+
+	rec := DoSSERequest(e, http.MethodPost, "/api/sse/admin/maintenance/toggle", &seed.AdminUser, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, "location.reload") {
+		t.Errorf("reload してはいけない。body: %s", body)
+	}
+	if !strings.Contains(body, "datastar-patch-elements") {
+		t.Errorf("datastar-patch-elements が無い。body: %s", body)
+	}
+	if !strings.Contains(body, "maintenance-panel") {
+		t.Errorf("maintenance-panel が patch に含まれない。body: %s", body)
 	}
 }
 

--- a/internal/integration/profile_test.go
+++ b/internal/integration/profile_test.go
@@ -1,0 +1,44 @@
+package integration
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestProfile_UpdateProfile_PatchesSignalNoReload は、プロフィール名の更新が
+// reload ではなく originalName signal の patch になっていることを担保する。
+// （シェルは email 表示で名前を出さないため、signal 更新だけで足りる）
+func TestProfile_UpdateProfile_PatchesSignalNoReload(t *testing.T) {
+	conn := SetupTestDB(t)
+	e := SetupTestServer(t, conn)
+	seed := SeedTestData(t, conn)
+
+	rec := DoSSERequest(e, http.MethodPut, "/api/sse/profile",
+		&seed.ViewerUser,
+		`{"profileName":"RenamedViewer"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	q := queryFromConn(conn)
+	user, err := q.GetUserByID(t.Context(), seed.ViewerUser.ID)
+	if err != nil {
+		t.Fatalf("ユーザー取得に失敗: %v", err)
+	}
+	if user.Name != "RenamedViewer" {
+		t.Errorf("Name = %q, want %q", user.Name, "RenamedViewer")
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, "location.reload") {
+		t.Errorf("reload してはいけない。body: %s", body)
+	}
+	if !strings.Contains(body, "datastar-patch-signals") {
+		t.Errorf("datastar-patch-signals が無い。body: %s", body)
+	}
+	if !strings.Contains(body, "originalName") {
+		t.Errorf("originalName signal の patch が無い。body: %s", body)
+	}
+}

--- a/internal/integration/testhelper.go
+++ b/internal/integration/testhelper.go
@@ -169,6 +169,9 @@ func registerTestSSERoutes(r chi.Router, queries *database.Queries, authMW func(
 	projectSSE := handlers.NewProjectSSEHandler(queries)
 	adminSSE := handlers.NewAdminSSEHandler(queries)
 	maintenanceHandler := handlers.NewMaintenanceHandler(queries)
+	// Profile: UpdateProfileSSE は magiclink 非依存なので ml=nil で登録できる
+	// （DeletePasskeysSSE は ml 依存のためテスト対象外）。
+	profileSSE := handlers.NewProfileSSEHandler(queries, nil)
 
 	requireWrite := appMiddleware.RequireRole("admin", "editor")
 	requireAdmin := appMiddleware.RequireRole("admin")
@@ -192,6 +195,9 @@ func registerTestSSERoutes(r chi.Router, queries *database.Queries, authMW func(
 
 			r.Post("/admin/maintenance/toggle", maintenanceHandler.ToggleSSE)
 		})
+
+		// Profile（認証のみ。UpdateProfileSSE は ml 非依存）
+		r.Put("/profile", profileSSE.UpdateProfileSSE)
 	})
 }
 

--- a/web/components/admin_maintenance.templ
+++ b/web/components/admin_maintenance.templ
@@ -3,7 +3,14 @@ package components
 templ AdminMaintenance(enabled bool) {
     <div class="max-w-2xl mx-auto space-y-6">
         @PageHeader("メンテナンスモード", "一般ユーザーのログイン受付を停止します。既にログイン中のユーザーのセッションは維持されます。")
+        @AdminMaintenancePanel(enabled)
+    </div>
+}
 
+// AdminMaintenancePanel は状態表示と切替ボタン。トグル時にサーバがこの要素だけを
+// patch する（reload しない）。
+templ AdminMaintenancePanel(enabled bool) {
+    <div id="maintenance-panel">
         @SectionCard() {
             if enabled {
                 <div class="flex items-center gap-3 rounded-md bg-amber-50 border border-amber-200 px-4 py-3">

--- a/web/components/profile.templ
+++ b/web/components/profile.templ
@@ -41,28 +41,36 @@ templ Profile(user database.User, hasPasskey bool) {
             }
 
             <!-- セキュリティ設定 (パスキー) -->
-            @SectionCard() {
-                @SectionCardTitle("セキュリティ", "パスキーを登録すると、次回から指紋認証や顔認証でログインできます。")
-
-                if hasPasskey {
-                    <div class="flex items-center p-3 mb-4 text-sm text-green-800 rounded-lg bg-green-50 border border-green-200">
-                        <svg class="flex-shrink-0 w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                            <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/>
-                        </svg>
-                        <span class="font-medium">登録済み</span>
-                    </div>
-                    <div class="flex flex-wrap gap-3">
-                        @SecondaryButton("別のパスキーを追加", templ.Attributes{"data-email": user.Email, "onclick": "registerPasskey(this.dataset.email)"})
-                        <button
-                            class="inline-flex items-center rounded-md bg-red-50 px-3 py-2 text-sm font-semibold text-red-600 shadow-sm ring-1 ring-inset ring-red-300 hover:bg-red-100"
-                            data-on:click="confirm('本当に全てのパスキーを削除しますか？次回からパスキーでログインできなくなります。') && @delete('/api/sse/profile/passkeys')"
-                        >全削除</button>
-                    </div>
-                } else {
-                    <div id="auth-messages" class="hidden mb-4"></div>
-                    @SecondaryButton("パスキーを登録する", templ.Attributes{"data-email": user.Email, "onclick": "registerPasskey(this.dataset.email)"})
-                }
-            }
+            @ProfileSecurityCard(user.Email, hasPasskey)
         </div>
+    </div>
+}
+
+// ProfileSecurityCard はパスキー設定カード。パスキー全削除時にサーバが
+// この要素だけを patch する（reload しない）。
+templ ProfileSecurityCard(email string, hasPasskey bool) {
+    <div id="profile-security">
+        @SectionCard() {
+            @SectionCardTitle("セキュリティ", "パスキーを登録すると、次回から指紋認証や顔認証でログインできます。")
+
+            if hasPasskey {
+                <div class="flex items-center p-3 mb-4 text-sm text-green-800 rounded-lg bg-green-50 border border-green-200">
+                    <svg class="flex-shrink-0 w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/>
+                    </svg>
+                    <span class="font-medium">登録済み</span>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                    @SecondaryButton("別のパスキーを追加", templ.Attributes{"data-email": email, "onclick": "registerPasskey(this.dataset.email)"})
+                    <button
+                        class="inline-flex items-center rounded-md bg-red-50 px-3 py-2 text-sm font-semibold text-red-600 shadow-sm ring-1 ring-inset ring-red-300 hover:bg-red-100"
+                        data-on:click="confirm('本当に全てのパスキーを削除しますか？次回からパスキーでログインできなくなります。') && @delete('/api/sse/profile/passkeys')"
+                    >全削除</button>
+                </div>
+            } else {
+                <div id="auth-messages" class="hidden mb-4"></div>
+                @SecondaryButton("パスキーを登録する", templ.Attributes{"data-email": email, "onclick": "registerPasskey(this.dataset.email)"})
+            }
+        }
     </div>
 }


### PR DESCRIPTION
## 概要
UI 更新方針（編集はダイアログ patch 主体）に沿って、admin users に続き maintenance と profile の「保存後 reload」を patch 化。

## 変更
| 対象 | Before | After |
|---|---|---|
| maintenance トグル | reload | `AdminMaintenancePanel` を patch（状態パネルだけ切替） |
| profile 名前更新 | reload | `originalName` signal を patch（保存ボタンが disabled に戻る） |
| profile パスキー全削除 | reload | `ProfileSecurityCard` を patch（未登録表示に切替） |

- シェルは email 表示で名前を出さないため、profile 名前更新は signal patch で足りる
- testhelper に profile ルート（`ml=nil`、`UpdateProfileSSE` は ml 非依存）を追加
- 回帰防止テスト追加（maintenance トグル / profile 名前更新）→ PASS
  - パスキー削除は ml 依存でテスト基盤外のため手動確認で担保

## 検証
- `make build`/`vet`/`lint`(0 issues)/全テスト(FAIL 0) 通過
- 実機（admin / ログインユーザー）で reload なしの部分更新を確認

## 補足
これで admin users / maintenance / profile が patch 化。残る projects は専用ページ設計のため、admin 流（一覧カードに編集/削除ボタン）へダイアログ化する大きめのリファクタを次段で行う。タグ（v0.6.0）はそのシリーズ完了時にまとめて打つ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)