### PR TITLE
全 patch 操作に成功トースト通知を追加

### DIFF
--- a/internal/handlers/admin_maintenance.go
+++ b/internal/handlers/admin_maintenance.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/database"
@@ -43,4 +44,9 @@ func (h *MaintenanceHandler) ToggleSSE(w http.ResponseWriter, r *http.Request) {
 	); err != nil {
 		logger.Error("SSE PatchElementTempl failed", "error", err)
 	}
+	state := "OFF"
+	if !cur {
+		state = "ON"
+	}
+	sendToast(sse, fmt.Sprintf("メンテナンスモードを%sにしました", state))
 }

--- a/internal/handlers/sse_admin.go
+++ b/internal/handlers/sse_admin.go
@@ -51,6 +51,7 @@ func (h *AdminSSEHandler) CreateUserDialogSSE(w http.ResponseWriter, r *http.Req
 		return
 	}
 	sse.ExecuteScript("document.getElementById('user-add-dialog')?.close()")
+	sendToast(sse, "ユーザーを追加しました")
 }
 
 func (h *AdminSSEHandler) createUser(ctx context.Context, name, email, role string) (database.User, error) {
@@ -151,6 +152,7 @@ func (h *AdminSSEHandler) UpdateUserSSE(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	sse.ExecuteScript("document.getElementById('user-edit-dialog')?.close()")
+	sendToast(sse, "ユーザーを更新しました")
 }
 
 func (h *AdminSSEHandler) DeleteUserSSE(w http.ResponseWriter, r *http.Request) {
@@ -177,4 +179,5 @@ func (h *AdminSSEHandler) DeleteUserSSE(w http.ResponseWriter, r *http.Request) 
 	if err := sse.RemoveElementByID(fmt.Sprintf("user-%d", id)); err != nil {
 		logger.Error("SSE RemoveElementByID failed", "error", err)
 	}
+	sendToast(sse, "ユーザーを削除しました")
 }

--- a/internal/handlers/sse_helpers.go
+++ b/internal/handlers/sse_helpers.go
@@ -1,12 +1,28 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/starfederation/datastar-go/datastar"
+
+	"github.com/naozine/project_crud_with_auth_tmpl/web/components"
 )
 
 // newSSE は ResponseWriter と Request から SSE ジェネレーターを作成する。
 func newSSE(w http.ResponseWriter, r *http.Request) *datastar.ServerSentEventGenerator {
 	return datastar.NewSSE(w, r)
+}
+
+// sendToast は #toast-container に通知を append し、数秒後に自動で取り除く。
+// patch 化により reload しなくなった操作の成功フィードバックに使う。
+func sendToast(sse *datastar.ServerSentEventGenerator, message string) {
+	id := fmt.Sprintf("toast-%d", time.Now().UnixNano())
+	_ = sse.PatchElementTempl(
+		components.Toast(id, message),
+		datastar.WithSelectorID("toast-container"),
+		datastar.WithModeAppend(),
+	)
+	_ = sse.ExecuteScript(fmt.Sprintf("setTimeout(() => document.getElementById('%s')?.remove(), 3000)", id))
 }

--- a/internal/handlers/sse_profile.go
+++ b/internal/handlers/sse_profile.go
@@ -57,6 +57,7 @@ func (h *ProfileSSEHandler) UpdateProfileSSE(w http.ResponseWriter, r *http.Requ
 	// シェルは email 表示で名前を出さないため、保存後は originalName を更新して
 	// 保存ボタンを disabled に戻すだけでよい（reload しない）。
 	_ = sse.MarshalAndPatchSignals(map[string]any{"originalName": signals.ProfileName})
+	sendToast(sse, "プロフィールを保存しました")
 }
 
 func (h *ProfileSSEHandler) DeletePasskeysSSE(w http.ResponseWriter, r *http.Request) {
@@ -84,4 +85,5 @@ func (h *ProfileSSEHandler) DeletePasskeysSSE(w http.ResponseWriter, r *http.Req
 	); err != nil {
 		logger.Error("SSE PatchElementTempl failed", "error", err)
 	}
+	sendToast(sse, "パスキーを削除しました")
 }

--- a/internal/handlers/sse_projects.go
+++ b/internal/handlers/sse_projects.go
@@ -59,6 +59,7 @@ func (h *ProjectSSEHandler) CreateProjectSSE(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	sse.ExecuteScript("document.getElementById('project-add-dialog')?.close()")
+	sendToast(sse, "プロジェクトを作成しました")
 }
 
 // EditProjectDialogSSE は編集ダイアログを挿入して開く（@get）。
@@ -126,6 +127,7 @@ func (h *ProjectSSEHandler) UpdateProjectSSE(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	sse.ExecuteScript("document.getElementById('project-edit-dialog')?.close()")
+	sendToast(sse, "プロジェクトを更新しました")
 }
 
 func (h *ProjectSSEHandler) DeleteProjectSSE(w http.ResponseWriter, r *http.Request) {
@@ -146,4 +148,5 @@ func (h *ProjectSSEHandler) DeleteProjectSSE(w http.ResponseWriter, r *http.Requ
 	if err := h.patchGrid(sse, r); err != nil {
 		logger.Error("SSE patchGrid failed", "error", err)
 	}
+	sendToast(sse, "プロジェクトを削除しました")
 }

--- a/internal/integration/project_test.go
+++ b/internal/integration/project_test.go
@@ -33,6 +33,10 @@ func TestProjects_CreateSSE_PatchesGridNoReload(t *testing.T) {
 	if !strings.Contains(body, "PatchedProject") {
 		t.Errorf("新プロジェクトが patch に含まれない。body: %s", body)
 	}
+	// 成功トースト（patch 化で reload しなくなった操作のフィードバック）
+	if !strings.Contains(body, "toast-container") || !strings.Contains(body, "プロジェクトを作成しました") {
+		t.Errorf("成功トーストが含まれていない。body: %s", body)
+	}
 }
 
 func TestProjects_UpdateSSE_PatchesCardNoReload(t *testing.T) {

--- a/web/components/toast.templ
+++ b/web/components/toast.templ
@@ -1,0 +1,10 @@
+package components
+
+// Toast は SSE で #toast-container に append される通知。
+// 数秒後にサーバ側の ExecuteScript で自動 remove される（handlers.sendToast 参照）。
+// patch 化で reload しなくなった操作の成功フィードバックに使う。
+templ Toast(id string, message string) {
+	<div id={ id } role="status" class="rounded-md bg-gray-900 px-4 py-2 text-sm text-white shadow-lg">
+		{ message }
+	</div>
+}

--- a/web/layouts/shell.templ
+++ b/web/layouts/shell.templ
@@ -168,6 +168,8 @@ templ Shell(title string, currentPath string, content templ.Component) {
 
 			<!-- Modal container for Datastar -->
 			<div id="modal-container"></div>
+			<!-- Toast container（SSE で append される成功通知。数秒で自動消去）-->
+			<div id="toast-container" class="fixed bottom-4 right-4 z-50 flex flex-col gap-2"></div>
 		</body>
 	</html>
 }


### PR DESCRIPTION
## 概要
reload を廃止した副作用（操作の成功が分かりにくい）を解消するため、汎用トーストを追加。`#toast-container` に append し3秒後に自動消去する。

## 変更
- `shell.templ` に `#toast-container`（右下固定）、`Toast` コンポーネント、`sendToast` ヘルパー
- 全 patch 操作の成功時にトースト:
  - profile:「プロフィールを保存しました」「パスキーを削除しました」
  - admin users:「ユーザーを追加/更新/削除しました」
  - projects:「プロジェクトを作成/更新/削除しました」
  - maintenance:「メンテナンスモードを ON/OFF にしました」
- project 作成トーストの回帰テスト追加

## 検証
- `make build`/`vet`/`lint`(0 issues)/全テスト(FAIL 0) 通過
- 実機で profile 保存時にトーストが出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)