### PR TITLE
エラーフィードバックを追加（汎用エラートースト + 送信前バリデーション）

### DIFF
--- a/web/components/admin_users_list.templ
+++ b/web/components/admin_users_list.templ
@@ -65,7 +65,7 @@ templ AdminUserEditDialog(user database.User) {
             }
 
             @DialogFooter("user-edit-dialog") {
-                @PrimaryButton("更新")
+                @PrimarySubmitButton("更新", "$editName.trim() === ''")
             }
         </form>
     }
@@ -128,7 +128,7 @@ templ adminUserAddDialog() {
             }
 
             @DialogFooter("user-add-dialog") {
-                @PrimaryButton("登録")
+                @PrimarySubmitButton("登録", "$newName.trim() === '' || $newEmail.trim() === ''")
             }
         </form>
     }

--- a/web/components/project_edit.templ
+++ b/web/components/project_edit.templ
@@ -17,7 +17,7 @@ templ ProjectEditDialog(project database.Project) {
             }
 
             @DialogFooter("project-edit-dialog") {
-                @PrimaryButton("保存")
+                @PrimarySubmitButton("保存", "$name.trim() === ''")
             }
         </form>
     }

--- a/web/components/project_list.templ
+++ b/web/components/project_list.templ
@@ -89,7 +89,7 @@ templ projectAddDialog() {
             }
 
             @DialogFooter("project-add-dialog") {
-                @PrimaryButton("作成")
+                @PrimarySubmitButton("作成", "$name.trim() === ''")
             }
         </form>
     }

--- a/web/components/ui_button.templ
+++ b/web/components/ui_button.templ
@@ -7,6 +7,16 @@ templ PrimaryButton(text string) {
     </button>
 }
 
+// PrimarySubmitButton は data-attr:disabled の式を受け取る送信ボタン。
+// 入力ミス（空など）を送信前に防ぐためのバリデーションに使う。
+templ PrimarySubmitButton(text string, disableExpr string) {
+    <button type="submit"
+        data-attr:disabled={ disableExpr }
+        class="rounded-md bg-black px-6 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black transition-colors">
+        { text }
+    </button>
+}
+
 // PrimaryButtonFull は横幅いっぱいのプライマリボタンを描画する。
 templ PrimaryButtonFull(text string) {
     <button type="submit" class="w-full rounded-md bg-black px-6 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black transition-colors">

--- a/web/layouts/shell.templ
+++ b/web/layouts/shell.templ
@@ -170,6 +170,22 @@ templ Shell(title string, currentPath string, content templ.Component) {
 			<div id="modal-container"></div>
 			<!-- Toast container（SSE で append される成功通知。数秒で自動消去）-->
 			<div id="toast-container" class="fixed bottom-4 right-4 z-50 flex flex-col gap-2"></div>
+			<!-- fetch エラーの汎用ハンドリング（4xx/5xx/ネットワーク）。
+			     datastar-fetch の detail にエラー本文は無いため汎用メッセージを出す。
+			     入力ミスは各フォームの送信ボタン disabled で送信前に防ぐ方針。-->
+			<div data-on:datastar-fetch__window="evt.detail.type === 'error' && showErrorToast()"></div>
+			<script>
+				function showErrorToast() {
+					var c = document.getElementById('toast-container');
+					if (!c) return;
+					var el = document.createElement('div');
+					el.className = 'rounded-md bg-red-600 px-4 py-2 text-sm text-white shadow-lg';
+					el.setAttribute('role', 'alert');
+					el.textContent = 'エラーが発生しました。時間をおいて再度お試しください。';
+					c.appendChild(el);
+					setTimeout(function () { el.remove(); }, 4000);
+				}
+			</script>
 		</body>
 	</html>
 }


### PR DESCRIPTION
## 概要
成功トースト（v0.6.0）と対になる**エラー時のフィードバック**を追加。reload を排した構成の穴（失敗が分からない）を埋める。

## 変更
1. **汎用 fetch エラーハンドラ**（`shell.templ`）: `data-on:datastar-fetch` の `type === 'error'` で全 fetch 失敗（4xx/5xx/ネットワーク）を捕捉し、赤いエラートーストを表示
   - `datastar-fetch` の detail にエラー本文が無い（公式未ドキュメント）ため、メッセージは汎用
2. **送信前バリデーション**: `PrimarySubmitButton`（`data-attr:disabled` 式付き）を追加し、作成・編集ダイアログの送信ボタンを空入力時に無効化
   - projects 作成/編集、admin users 追加/編集に適用

これで「入力ミス → 送信前に無効化」「想定外エラー → 赤トースト」の両面をカバー。

## 検証
- `make build`/`vet`/`lint`(0 issues)/全テスト(FAIL 0) 通過
- 実機で送信ボタン無効化・オフライン時のエラートーストを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)