### PR TITLE
confirm() をカスタム確認ダイアログに置き換え

### DIFF
--- a/web/components/admin_maintenance.templ
+++ b/web/components/admin_maintenance.templ
@@ -26,7 +26,7 @@ templ AdminMaintenancePanel(enabled bool) {
                     <button
                         type="button"
                         class="inline-flex items-center rounded-md bg-black px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
-                        data-on:click="confirm('メンテナンスモードを解除しますか？') && @post('/api/sse/admin/maintenance/toggle')"
+                        data-on:click="$confirmMsg = 'メンテナンスモードを解除しますか？'; $confirmUrl = '/api/sse/admin/maintenance/toggle'; $confirmMethod = 'post'; document.getElementById('confirm-dialog').showModal()"
                     >メンテナンスモードを解除</button>
                 </div>
             } else {
@@ -43,7 +43,7 @@ templ AdminMaintenancePanel(enabled bool) {
                     <button
                         type="button"
                         class="inline-flex items-center rounded-md bg-white px-4 py-2 text-sm font-semibold text-amber-700 shadow-sm ring-1 ring-inset ring-amber-300 hover:bg-amber-50"
-                        data-on:click="confirm('メンテナンスモードを開始しますか？\n\n一般ユーザーはログインできなくなります（既にログイン中のセッションは維持されます）。') && @post('/api/sse/admin/maintenance/toggle')"
+                        data-on:click="$confirmMsg = 'メンテナンスモードを開始しますか？ 一般ユーザーはログインできなくなります（ログイン中のセッションは維持されます）。'; $confirmUrl = '/api/sse/admin/maintenance/toggle'; $confirmMethod = 'post'; document.getElementById('confirm-dialog').showModal()"
                     >メンテナンスモードを開始</button>
                 </div>
             }

--- a/web/components/admin_users_list.templ
+++ b/web/components/admin_users_list.templ
@@ -100,7 +100,7 @@ templ AdminUserCard(user database.User) {
                     >編集</button>
                     <button
                         class="text-red-600 hover:text-red-800 text-sm font-medium"
-                        data-on:click={ fmt.Sprintf("confirm('本当にこのユーザーを削除しますか？') && @delete('/api/sse/admin/users/%d')", user.ID) }
+                        data-on:click={ fmt.Sprintf("$confirmMsg = '本当にこのユーザーを削除しますか？'; $confirmUrl = '/api/sse/admin/users/%d'; $confirmMethod = 'delete'; document.getElementById('confirm-dialog').showModal()", user.ID) }
                     >削除</button>
                 </div>
             </div>

--- a/web/components/profile.templ
+++ b/web/components/profile.templ
@@ -64,7 +64,7 @@ templ ProfileSecurityCard(email string, hasPasskey bool) {
                     @SecondaryButton("別のパスキーを追加", templ.Attributes{"data-email": email, "onclick": "registerPasskey(this.dataset.email)"})
                     <button
                         class="inline-flex items-center rounded-md bg-red-50 px-3 py-2 text-sm font-semibold text-red-600 shadow-sm ring-1 ring-inset ring-red-300 hover:bg-red-100"
-                        data-on:click="confirm('本当に全てのパスキーを削除しますか？次回からパスキーでログインできなくなります。') && @delete('/api/sse/profile/passkeys')"
+                        data-on:click="$confirmMsg = '本当に全てのパスキーを削除しますか？次回からパスキーでログインできなくなります。'; $confirmUrl = '/api/sse/profile/passkeys'; $confirmMethod = 'delete'; document.getElementById('confirm-dialog').showModal()"
                     >全削除</button>
                 </div>
             } else {

--- a/web/components/project_list.templ
+++ b/web/components/project_list.templ
@@ -67,7 +67,7 @@ templ ProjectCard(p database.Project, canWrite bool) {
                         >編集</button>
                         <button
                             class="text-red-600 hover:text-red-800 text-sm font-medium"
-                            data-on:click={ fmt.Sprintf("confirm('本当に削除しますか？') && @delete('/api/sse/projects/%d')", p.ID) }
+                            data-on:click={ fmt.Sprintf("$confirmMsg = '本当に削除しますか？'; $confirmUrl = '/api/sse/projects/%d'; $confirmMethod = 'delete'; document.getElementById('confirm-dialog').showModal()", p.ID) }
                         >削除</button>
                     </div>
                 }

--- a/web/layouts/shell.templ
+++ b/web/layouts/shell.templ
@@ -168,6 +168,15 @@ templ Shell(title string, currentPath string, content templ.Component) {
 
 			<!-- Modal container for Datastar -->
 			<div id="modal-container"></div>
+			<!-- 汎用確認ダイアログ（ネイティブ confirm の置き換え）。
+			     各操作ボタンが $confirmMsg/$confirmUrl/$confirmMethod を設定して開く。-->
+			<dialog id="confirm-dialog" data-signals="{confirmMsg: '', confirmUrl: '', confirmMethod: 'delete'}" class="m-auto max-w-sm rounded-lg p-6 backdrop:bg-black/30">
+				<p class="mb-5 text-sm text-gray-700" data-text="$confirmMsg"></p>
+				<div class="flex justify-end gap-2">
+					<button type="button" class="rounded bg-gray-200 px-3 py-1.5 text-sm" data-on:click="document.getElementById('confirm-dialog').close()">キャンセル</button>
+					<button type="button" class="rounded bg-red-600 px-3 py-1.5 text-sm text-white" data-on:click="document.getElementById('confirm-dialog').close(); $confirmMethod === 'delete' ? @delete($confirmUrl) : @post($confirmUrl)">OK</button>
+				</div>
+			</dialog>
 			<!-- Toast container（SSE で append される成功通知。数秒で自動消去）-->
 			<div id="toast-container" class="fixed bottom-4 right-4 z-50 flex flex-col gap-2"></div>
 			<!-- fetch エラーの汎用ハンドリング（4xx/5xx/ネットワーク）。


### PR DESCRIPTION
## 概要
reload を排した Datastar 構成に残っていた**ネイティブ `confirm()`** をカスタムモーダル確認ダイアログに置き換え、UI の一貫性を完成させる。

## 変更
- `shell.templ` に汎用 `confirm-dialog`（中央モーダル、`$confirmMsg`/`$confirmUrl`/`$confirmMethod` を signal で保持）
- 削除・トグル系の全ボタンが、`confirm()` の代わりに signal を設定してダイアログを開く方式に:
  - admin users 削除 / projects 削除 / profile パスキー削除（`@delete`）
  - maintenance トグル（`@post`）
- OK ボタンが `$confirmMethod` に応じて `@delete`/`@post` を実行

## 検証
- `make build`/`vet`/`lint`(0 issues)/全テスト(FAIL 0) 通過、`confirm(` の残数 **0**
- 実機で削除・トグルがカスタムダイアログ経由になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)