### PR TITLE
SSE 書き込みに body 上限を追加（DoS 対策）

### DIFF
--- a/internal/handlers/sse_admin.go
+++ b/internal/handlers/sse_admin.go
@@ -29,8 +29,7 @@ func (h *AdminSSEHandler) CreateUserDialogSSE(w http.ResponseWriter, r *http.Req
 		NewEmail string `json:"newEmail"`
 		NewRole  string `json:"newRole"`
 	}
-	if err := datastar.ReadSignals(r, &signals); err != nil {
-		http.Error(w, "無効なリクエストです", http.StatusBadRequest)
+	if !readSignalsOr413(w, r, &signals) {
 		return
 	}
 
@@ -117,8 +116,7 @@ func (h *AdminSSEHandler) UpdateUserSSE(w http.ResponseWriter, r *http.Request) 
 		EditRole   string `json:"editRole"`
 		EditStatus string `json:"editStatus"`
 	}
-	if err := datastar.ReadSignals(r, &signals); err != nil {
-		http.Error(w, "無効なリクエストです", http.StatusBadRequest)
+	if !readSignalsOr413(w, r, &signals) {
 		return
 	}
 

--- a/internal/handlers/sse_helpers.go
+++ b/internal/handlers/sse_helpers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -13,6 +14,22 @@ import (
 // newSSE は ResponseWriter と Request から SSE ジェネレーターを作成する。
 func newSSE(w http.ResponseWriter, r *http.Request) *datastar.ServerSentEventGenerator {
 	return datastar.NewSSE(w, r)
+}
+
+// readSignalsOr413 は Datastar signals を読み込む。body 上限超過なら 413、
+// その他のパースエラーなら 400 を返して false を返す（呼び出し元は return すること）。
+// 上限は SSE ルートの MaxBodySize ミドルウェアで設定する。
+func readSignalsOr413(w http.ResponseWriter, r *http.Request, signals any) bool {
+	if err := datastar.ReadSignals(r, signals); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "リクエストが大きすぎます", http.StatusRequestEntityTooLarge)
+			return false
+		}
+		http.Error(w, "無効なリクエストです", http.StatusBadRequest)
+		return false
+	}
+	return true
 }
 
 // sendToast は #toast-container に通知を append し、数秒後に自動で取り除く。

--- a/internal/handlers/sse_profile.go
+++ b/internal/handlers/sse_profile.go
@@ -32,8 +32,7 @@ func (h *ProfileSSEHandler) UpdateProfileSSE(w http.ResponseWriter, r *http.Requ
 	var signals struct {
 		ProfileName string `json:"profileName"`
 	}
-	if err := datastar.ReadSignals(r, &signals); err != nil {
-		http.Error(w, "無効なリクエストです", http.StatusBadRequest)
+	if !readSignalsOr413(w, r, &signals) {
 		return
 	}
 

--- a/internal/handlers/sse_projects.go
+++ b/internal/handlers/sse_projects.go
@@ -38,8 +38,7 @@ func (h *ProjectSSEHandler) CreateProjectSSE(w http.ResponseWriter, r *http.Requ
 	var signals struct {
 		Name string `json:"name"`
 	}
-	if err := datastar.ReadSignals(r, &signals); err != nil {
-		http.Error(w, "無効なリクエストです", http.StatusBadRequest)
+	if !readSignalsOr413(w, r, &signals) {
 		return
 	}
 	if signals.Name == "" {
@@ -96,8 +95,7 @@ func (h *ProjectSSEHandler) UpdateProjectSSE(w http.ResponseWriter, r *http.Requ
 	var signals struct {
 		Name string `json:"name"`
 	}
-	if err := datastar.ReadSignals(r, &signals); err != nil {
-		http.Error(w, "無効なリクエストです", http.StatusBadRequest)
+	if !readSignalsOr413(w, r, &signals) {
 		return
 	}
 

--- a/internal/integration/body_size_test.go
+++ b/internal/integration/body_size_test.go
@@ -16,11 +16,35 @@ import (
 
 // G120 (DoS / メモリ・ディスク枯渇) 対策のテスト。
 // 各ハンドラの直前で http.MaxBytesReader を仕掛け、上限超過時に 413 を返すこと。
-// 上限値は internal/limits パッケージで定義（ProjectFormBody, UserImportBody）。
+// 上限値は internal/limits パッケージで定義（SSESignalBody, UserImportBody）。
 
-// 注: projects の作成・更新は Datastar SSE（/api/sse/projects/*）に一本化され、
-// 旧 PRG ルート（/projects/new 等）の MaxBodySize テストは廃止した。SSE 版への
-// body 上限付与は別途の課題（現状は付いていない）。
+// ---------------------------------------------------------------------------
+// Project SSE: POST /api/sse/projects/new（signals JSON の body 上限）
+// ---------------------------------------------------------------------------
+
+func TestProjectsSSE_CreateOverLimit(t *testing.T) {
+	conn := SetupTestDB(t)
+	e := SetupTestServer(t, conn)
+	seed := SeedTestData(t, conn)
+
+	// 上限を確実に超える signals JSON（上限の 2 倍の name）
+	body := `{"name":"` + strings.Repeat("x", 2*limits.SSESignalBody) + `"}`
+	rec := DoSSERequest(e, http.MethodPost, "/api/sse/projects/new", &seed.AdminUser, body)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("ステータスコード = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+
+	// 上限超過時はレコードが作成されないこと（seed の 1 件のまま）
+	q := queryFromConn(conn)
+	projects, err := q.ListProjects(t.Context())
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if len(projects) != 1 {
+		t.Errorf("Project 件数 = %d, want 1（上限超過後にレコードが追加されている）", len(projects))
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Excel インポート: POST /admin/users/import

--- a/internal/integration/testhelper.go
+++ b/internal/integration/testhelper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/appcontext"
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/database"
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/handlers"
+	"github.com/naozine/project_crud_with_auth_tmpl/internal/limits"
 	appMiddleware "github.com/naozine/project_crud_with_auth_tmpl/internal/middleware"
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/routes"
 	"github.com/pressly/goose/v3"
@@ -178,6 +179,7 @@ func registerTestSSERoutes(r chi.Router, queries *database.Queries, authMW func(
 
 	r.Route("/api/sse", func(r chi.Router) {
 		r.Use(authMW)
+		r.Use(appMiddleware.MaxBodySize(limits.SSESignalBody))
 
 		r.Group(func(r chi.Router) {
 			r.Use(requireWrite)

--- a/internal/limits/limits.go
+++ b/internal/limits/limits.go
@@ -5,9 +5,9 @@
 package limits
 
 const (
-	// ProjectFormBody は /projects/* の POST/PUT 受信 body 上限。
-	// プロジェクト名等の小さなフォーム送信のみを想定。
-	ProjectFormBody = 1 << 20 // 1 MB
+	// SSESignalBody は Datastar SSE（@post/@put）の signals JSON 受信 body 上限。
+	// プロジェクト名・ユーザー名等の小さな signals のみを想定。
+	SSESignalBody = 1 << 20 // 1 MB
 
 	// UserImportBody は /admin/users/import の multipart 受信 body 上限。
 	// 5 MB の Excel ファイル + multipart オーバーヘッド分の余裕を見込む。

--- a/internal/routes/sse.go
+++ b/internal/routes/sse.go
@@ -7,6 +7,7 @@ import (
 	"github.com/naozine/nz-magic-link/magiclink"
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/database"
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/handlers"
+	"github.com/naozine/project_crud_with_auth_tmpl/internal/limits"
 	appMiddleware "github.com/naozine/project_crud_with_auth_tmpl/internal/middleware"
 	"github.com/naozine/project_crud_with_auth_tmpl/internal/roles"
 )
@@ -23,6 +24,8 @@ func RegisterSSERoutes(r chi.Router, queries *database.Queries, ml *magiclink.Ma
 
 	r.Route("/api/sse", func(r chi.Router) {
 		r.Use(authMW)
+		// SSE 書き込み（@post/@put）の signals JSON body 上限（DoS 対策）。
+		r.Use(appMiddleware.MaxBodySize(limits.SSESignalBody))
 
 		// Projects
 		r.Group(func(r chi.Router) {


### PR DESCRIPTION
## 概要
projects のダイアログ化（死コード削除）で抜けていた SSE の body 上限を補う。projects だけでなく admin users / profile も同じ穴だったため、**SSE 書き込み全体**に適用する。

## 変更
- `limits.ProjectFormBody`（死コード削除で未使用化）→ **`SSESignalBody`（1MB）**にリネーム
- `/api/sse/*` 全体に `MaxBodySize(SSESignalBody)` ミドルウェアを適用（本番 + testhelper）
- `readSignalsOr413` ヘルパー: body 上限超過なら **413**、その他のパースエラーは 400
- 各 SSE 書き込みハンドラ（projects/admin/profile）の `ReadSignals` を置換
- SSE body 上限の回帰テスト追加（413 ＋ レコード未作成を確認）

## 検証
- `make build`/`vet`/`lint`(0 issues)/全テスト(FAIL 0) 通過
- `TestProjectsSSE_CreateOverLimit` で 413 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)