### PR TITLE
patch に View Transition（フェード）を導入

### DIFF
--- a/docs/datastar/datastar-llm-guide.md
+++ b/docs/datastar/datastar-llm-guide.md
@@ -545,13 +545,20 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 These options map 1:1 to the SSE `selector` / `mode` / `useViewTransition` data keys in §7.
 
+> **Fade/transition for free.** Adding `WithViewTransitions()` to a patch wraps the DOM
+> change in the View Transition API, whose browser default is a **crossfade** — so card
+> updates, list re-renders, and toasts fade smoothly with no extra CSS. Scope the
+> transition to one element with the SSE `viewTransitionSelector` (added v1.0.2).
+> Non-supporting browsers fall back to an instant update (progressive enhancement).
+
 ### Live recipes
 A runnable, source-annotated recipe set is served at **`/datastar/recipes`** (public,
 DB-free in-memory demos): two-way bind, server round-trip counter, in-memory TODO CRUD,
 live search, indicator, polling, dialog, dropdown, a **JS-free virtual scroll**
 (server round-trip windowing), and **dialog edit with no navigation/reload** (the
 SPA-style alternative to PRG: edit in a dialog → `@put` → server patches just that row
-and closes the dialog — no page transition, no reload). Source to copy from:
+and closes the dialog — no page transition, no reload), and a **view-transition fade**
+(`data-on:click__viewtransition`). Source to copy from:
 `web/components/datastar_recipes.templ` + `internal/handlers/datastar_recipes.go`.
 
 > **Virtual scroll — core vs Pro.** The core recipe keeps the DOM to a fixed number

--- a/internal/handlers/admin_maintenance.go
+++ b/internal/handlers/admin_maintenance.go
@@ -41,6 +41,7 @@ func (h *MaintenanceHandler) ToggleSSE(w http.ResponseWriter, r *http.Request) {
 		components.AdminMaintenancePanel(!cur),
 		datastar.WithSelectorID("maintenance-panel"),
 		datastar.WithModeOuter(),
+		datastar.WithViewTransitions(),
 	); err != nil {
 		logger.Error("SSE PatchElementTempl failed", "error", err)
 	}

--- a/internal/handlers/sse_admin.go
+++ b/internal/handlers/sse_admin.go
@@ -45,6 +45,7 @@ func (h *AdminSSEHandler) CreateUserDialogSSE(w http.ResponseWriter, r *http.Req
 		components.AdminUserCard(user),
 		datastar.WithSelectorID("users-table"),
 		datastar.WithModeAppend(),
+		datastar.WithViewTransitions(),
 	); err != nil {
 		logger.Error("SSE PatchElementTempl failed", "error", err)
 		return
@@ -145,6 +146,7 @@ func (h *AdminSSEHandler) UpdateUserSSE(w http.ResponseWriter, r *http.Request) 
 		components.AdminUserCard(user),
 		datastar.WithSelectorID(fmt.Sprintf("user-%d", id)),
 		datastar.WithModeOuter(),
+		datastar.WithViewTransitions(),
 	); err != nil {
 		logger.Error("SSE PatchElementTempl failed", "error", err)
 		return
@@ -174,8 +176,8 @@ func (h *AdminSSEHandler) DeleteUserSSE(w http.ResponseWriter, r *http.Request) 
 
 	sse := newSSE(w, r)
 	// 該当カードを除去する（reload しない）。
-	if err := sse.RemoveElementByID(fmt.Sprintf("user-%d", id)); err != nil {
-		logger.Error("SSE RemoveElementByID failed", "error", err)
+	if err := sse.RemoveElement(fmt.Sprintf("#user-%d", id), datastar.WithViewTransitions()); err != nil {
+		logger.Error("SSE RemoveElement failed", "error", err)
 	}
 	sendToast(sse, "ユーザーを削除しました")
 }

--- a/internal/handlers/sse_helpers.go
+++ b/internal/handlers/sse_helpers.go
@@ -34,12 +34,15 @@ func readSignalsOr413(w http.ResponseWriter, r *http.Request, signals any) bool 
 
 // sendToast は #toast-container に通知を append し、数秒後に自動で取り除く。
 // patch 化により reload しなくなった操作の成功フィードバックに使う。
+// 表示は View Transition（既定クロスフェード）でフェードイン、削除も
+// startViewTransition でフェードアウトする（非対応ブラウザは即時）。
 func sendToast(sse *datastar.ServerSentEventGenerator, message string) {
 	id := fmt.Sprintf("toast-%d", time.Now().UnixNano())
 	_ = sse.PatchElementTempl(
 		components.Toast(id, message),
 		datastar.WithSelectorID("toast-container"),
 		datastar.WithModeAppend(),
+		datastar.WithViewTransitions(),
 	)
-	_ = sse.ExecuteScript(fmt.Sprintf("setTimeout(() => document.getElementById('%s')?.remove(), 3000)", id))
+	_ = sse.ExecuteScript(fmt.Sprintf("setTimeout(function(){var e=document.getElementById('%s');if(!e)return;document.startViewTransition?document.startViewTransition(function(){e.remove()}):e.remove()},3000)", id))
 }

--- a/internal/handlers/sse_profile.go
+++ b/internal/handlers/sse_profile.go
@@ -81,6 +81,7 @@ func (h *ProfileSSEHandler) DeletePasskeysSSE(w http.ResponseWriter, r *http.Req
 		components.ProfileSecurityCard(email, false),
 		datastar.WithSelectorID("profile-security"),
 		datastar.WithModeOuter(),
+		datastar.WithViewTransitions(),
 	); err != nil {
 		logger.Error("SSE PatchElementTempl failed", "error", err)
 	}

--- a/internal/handlers/sse_projects.go
+++ b/internal/handlers/sse_projects.go
@@ -31,6 +31,7 @@ func (h *ProjectSSEHandler) patchGrid(sse *datastar.ServerSentEventGenerator, r 
 		components.ProjectCards(projects, true),
 		datastar.WithSelectorID("projects-grid"),
 		datastar.WithModeInner(),
+		datastar.WithViewTransitions(),
 	)
 }
 
@@ -120,6 +121,7 @@ func (h *ProjectSSEHandler) UpdateProjectSSE(w http.ResponseWriter, r *http.Requ
 		components.ProjectCard(project, true),
 		datastar.WithSelectorID(fmt.Sprintf("project-%d", id)),
 		datastar.WithModeOuter(),
+		datastar.WithViewTransitions(),
 	); err != nil {
 		logger.Error("SSE PatchElementTempl failed", "error", err)
 		return

--- a/web/components/datastar_recipes.templ
+++ b/web/components/datastar_recipes.templ
@@ -121,6 +121,13 @@ templ DatastarRecipes(todos []RecipeTodo, items []RecipeItem) {
 						<div id="recipe-item-dialog-container"></div>
 					</div>
 				}
+				<!-- 11. View Transition でフェード -->
+				@recipeCard("11. View Transition でフェード（__viewtransition）", "data-on:click__viewtransition でクリックハンドラを View Transition でラップ。表示切替が既定クロスフェード（v1.0.2、CSS で 0.4s）でフェードする。サーバ patch なら WithViewTransitions()。", RecipeVTFront, "") {
+					<div data-signals:vtshow="true">
+						<button class="bg-blue-600 text-white px-3 py-1 rounded" data-on:click__viewtransition="$vtshow = !$vtshow">toggle</button>
+						<div data-show="$vtshow" class="mt-3 rounded bg-emerald-100 p-4">この要素が View Transition でフェードします</div>
+					</div>
+				}
 			</div>
 		</body>
 	</html>

--- a/web/components/recipe_data.go
+++ b/web/components/recipe_data.go
@@ -195,3 +195,12 @@ func RecipeItemUpdate(w http.ResponseWriter, r *http.Request) {
         datastar.WithSelectorID(fmt.Sprintf("item-%d", id)), datastar.WithModeOuter())
     sse.ExecuteScript("document.getElementById('recipe-item-dialog').close()")
 }`
+
+// 11. View Transition でフェード（フロントのみ。v1.0.2 の viewTransitionSelector と
+// 同じ View Transition API を data-on の __viewtransition 修飾子で使う）
+const RecipeVTFront = `<div data-signals:vtshow="true">
+  <!-- __viewtransition でクリックハンドラを View Transition でラップ。
+       表示切替が既定クロスフェードでフェードする（CSS で 0.4s に調整済み）。 -->
+  <button data-on:click__viewtransition="$vtshow = !$vtshow">toggle</button>
+  <div data-show="$vtshow">この要素が View Transition でフェードします</div>
+</div>`

--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -20,3 +20,11 @@
 #nav-menu::backdrop {
     background: rgb(107 114 128 / 0.75);
 }
+
+/* View Transition: 既定のクロスフェードを長め(0.4s)にして視認性を上げる。
+   カード更新・リスト再描画・トーストの出入りのフェードが分かりやすくなる。
+   非対応ブラウザでは無視され、即時更新にフォールバックする。 */
+::view-transition-old(root),
+::view-transition-new(root) {
+    animation-duration: 0.4s;
+}


### PR DESCRIPTION
## 概要
v1.0.2 の `viewTransitionSelector` / `WithViewTransitions()` を使い、SSE patch を View Transition でラップしてフェードさせる。

## 変更
- 各 patch（カード更新 / リスト再描画 / maintenance パネル / profile セキュリティ / トースト）に `WithViewTransitions()`
  - トーストは要素の出入りでフェードが明確、カード更新は内容が似ており subtle（View Transition の本質的特性）
- トースト削除は `startViewTransition` でフェードアウト
- `input.css` にクロスフェード 0.4s の CSS（視認性向上。非対応ブラウザは即時更新にフォールバック）
- **レシピ⑪「View Transition でフェード」**（`data-on:click__viewtransition`）を追加
- guide §12 に活用を追記、レシピ一覧を更新

## 検証
- `make build`/`vet`/`lint`(0 issues)/全テスト(FAIL 0) 通過
- トースト・レシピ⑪のフェードを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)