### PR TITLE
CI: templ CLI を go.mod のバージョンに固定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
 
       - name: Install code generators
         run: |
-          go install github.com/a-h/templ/cmd/templ@latest
+          # templ CLI は go.mod のランタイムと同じバージョンに揃える。
+          # @latest だと新版 CLI が古いランタイムに無い API を呼ぶ生成コードを吐いて
+          # ビルドが壊れることがある（2026-05-30 の ResolveAttributeValue 事故）。
+          go install github.com/a-h/templ/cmd/templ@$(go list -m -f '{{.Version}}' github.com/a-h/templ)
           go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
           # tailwindcss はバージョン固定（minify 出力がバージョンで変わるため、ローカルの make generate と揃える）
           TAILWIND_VERSION=v4.2.1


### PR DESCRIPTION
## 概要
CI が templ CLI を `@latest` でインストールしているため、go.mod で固定しているランタイム（`github.com/a-h/templ`）とバージョンがズレることがある。新版 CLI が古いランタイムに存在しない API を呼ぶ生成コードを吐くと、リポジトリ側は何も変えていないのに CI が壊れる。

実際に 2026-05-30 時点の `@latest` が `templ.ResolveAttributeValue` を呼ぶコードを生成し、dependabot の #72（sqlite バンプ）の CI が依存とは無関係に失敗していた。

## 変更内容
- `go list -m -f '{{.Version}}' github.com/a-h/templ` で go.mod のバージョンを取得し、同じバージョンの CLI をインストールするように変更
- これで templ を上げるときは go.mod のバンプだけで CLI も追従する（手動の二重管理は不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)